### PR TITLE
Add Coveralls.io integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 target/
 src/main/c/h3-java/src/com_uber_h3core_NativeMethods.h
 dependency-reduced-pom.xml
+
+src/main/resources/*h3*

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,12 @@ os: linux
 dist: trusty
 
 jdk:
-  - oraclejdk8
+  - oraclejdk9
   - openjdk8
 
 matrix:
   include:
     - env: NAME="Coverage report"
-      jdk: oraclejdk9
-      after_success:
+      jdk: oraclejdk8
+      script:
         - mvn clean test jacoco:report coveralls:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,11 @@ dist: trusty
 
 jdk:
   - oraclejdk8
-  - oraclejdk9
   - openjdk8
+
+matrix:
+  include:
+    - env: NAME="Coverage report"
+      jdk: oraclejdk9
+      after_success:
+        - mvn clean test jacoco:report coveralls:report

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # H3-Java
 
+[![Build Status](https://travis-ci.org/uber/h3-java.svg?branch=master)](https://travis-ci.org/uber/h3-java)
+[![Coverage Status](https://coveralls.io/repos/github/uber/h3-java/badge.svg?branch=master)](https://coveralls.io/github/uber/h3-java?branch=master)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
 This library provides Java bindings for the [H3 Core Library](https://github.com/uber/h3). For API reference, please see the [H3 Documentation](https://uber.github.io/h3/).

--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,11 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
+                <version>4.3.0</version>
+            </plugin>
         </plugins>
         <resources>
             <resource>

--- a/src/test/java/com/uber/h3core/util/TestVector2D.java
+++ b/src/test/java/com/uber/h3core/util/TestVector2D.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.h3core.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ *
+ */
+public class TestVector2D {
+    @Test
+    public void test() {
+        Vector2D v1 = new Vector2D(0, 1);
+        Vector2D v2 = new Vector2D(1, 0);
+        Vector2D v3 = new Vector2D(0, 1);
+
+        assertNotEquals(null, v1);
+        assertNotEquals(0, v1);
+        assertNotEquals(v1, v2);
+        assertNotEquals(v3, v2);
+        assertEquals(v1, v3);
+
+        assertEquals(v1.hashCode(), v3.hashCode());
+        // Not strictly needed, but likely
+        assertNotEquals(v1.hashCode(), v2.hashCode());
+    }
+
+    @Test
+    public void testToString() {
+        Vector2D v = new Vector2D(123.456, 456.789);
+
+        String toString = v.toString();
+        assertTrue(toString.contains("x=123.456"));
+        assertTrue(toString.contains("y=456.789"));
+    }
+}


### PR DESCRIPTION
Adds Coveralls integration, and badges for Coveralls and Travis CI. Coverage only includes Java sources right now, not JNI sources.

Also adds TestVector2D.java, which was missing from the repo.