### PR TITLE
Cross compile via dockcross

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ src/main/c/h3-java/src/com_uber_h3core_NativeMethods.h
 dependency-reduced-pom.xml
 
 src/main/resources/*h3*
+src/main/resources/darwin-*
+src/main/resources/android-*
+src/main/resources/linux-*
+src/main/resources/windows-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,17 +14,20 @@
 
 language: java
 
-os: linux
-dist: trusty
+sudo: required
 
-jdk:
-  - oraclejdk9
-  - openjdk8
+services:
+  - docker
 
 matrix:
   include:
-    - env: NAME="Coverage report"
+    - os: linux
+      env: NAME="Coverage report"
       jdk: oraclejdk8
       script:
         - mvn clean test jacoco:report coveralls:report
+    - os: linux
+      jdk: openjdk8
+    - os: linux
+      jdk: oraclejdk9
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,4 @@ matrix:
       jdk: oraclejdk8
       script:
         - mvn clean test jacoco:report coveralls:report
+    - os: osx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The public API of this library consists of the public functions declared in
 file [H3Core.java](./src/main/java/com/uber/h3core/H3Core.java).
 
 ## [Unreleased]
+### Added
+- Added script for cross compiling using dockcross.
+- Changed the native library loader to detect more operating systems.
 
 ## [3.0.0] - 2018-03-27
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
 
         <h3.git.remote>https://github.com/uber/h3.git</h3.git.remote>
         <h3.git.reference>v3.0.3</h3.git.reference>
+        <h3.crosscompile>true</h3.crosscompile>
     </properties>
 
     <dependencies>
@@ -129,6 +130,7 @@
                             <arguments>
                                 <argument>${h3.git.remote}</argument>
                                 <argument>${h3.git.reference}</argument>
+                                <argument>${h3.crosscompile}</argument>
                             </arguments>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
         <h3.git.remote>https://github.com/uber/h3.git</h3.git.remote>
         <h3.git.reference>v3.0.3</h3.git.reference>
-        <h3.crosscompile>true</h3.crosscompile>
+        <h3.use.docker>true</h3.use.docker>
     </properties>
 
     <dependencies>
@@ -130,7 +130,7 @@
                             <arguments>
                                 <argument>${h3.git.remote}</argument>
                                 <argument>${h3.git.reference}</argument>
-                                <argument>${h3.crosscompile}</argument>
+                                <argument>${h3.use.docker}</argument>
                             </arguments>
                         </configuration>
                     </execution>

--- a/src/main/c/h3-java/CMakeLists.txt
+++ b/src/main/c/h3-java/CMakeLists.txt
@@ -16,6 +16,9 @@
 
 cmake_minimum_required(VERSION 3.1)
 
+set(CMAKE_C_STANDARD_REQUIRED 1)
+set(CMAKE_C_STANDARD 11)
+
 # Needed due to CMP0042
 set(CMAKE_MACOSX_RPATH 1)
 set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cmake/toolchain.cmake"
@@ -26,10 +29,18 @@ set(H3_SOVERSION 1)
 
 project(h3-java)
 
-find_package(JNI)
-
 include_directories(${H3_ROOT}/src/h3lib/include)
-include_directories(${JNI_INCLUDE_DIRS})
+
+if(USE_NATIVE_JNI)
+    find_package(JNI REQUIRED)
+
+    include_directories(${JNI_INCLUDE_DIRS})
+else()
+    include_directories(/java/include)
+    # TODO Provide correct jni_md.h
+    include_directories(/java/include/linux)
+    include_directories(/java/include/darwin)
+endif()
 
 # For building H3 itself
 add_subdirectory(${H3_ROOT} build)

--- a/src/main/c/h3-java/CMakeLists.txt
+++ b/src/main/c/h3-java/CMakeLists.txt
@@ -19,6 +19,8 @@ cmake_minimum_required(VERSION 3.1)
 set(CMAKE_C_STANDARD_REQUIRED 1)
 set(CMAKE_C_STANDARD 11)
 
+include(CMakeDependentOption)
+
 # Needed due to CMP0042
 set(CMAKE_MACOSX_RPATH 1)
 set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cmake/toolchain.cmake"
@@ -29,7 +31,7 @@ set(H3_SOVERSION 1)
 
 project(h3-java)
 
-include_directories(${H3_ROOT}/src/h3lib/include)
+include_directories(${H3_SRC_ROOT}/src/h3lib/include)
 
 if(USE_NATIVE_JNI)
     find_package(JNI REQUIRED)
@@ -42,20 +44,13 @@ else()
     include_directories(/java/include/darwin)
 endif()
 
-# For building H3 itself
-add_subdirectory(${H3_ROOT} build)
-
 set(JNI_SOURCE_FILES
     ${PROJECT_SOURCE_DIR}/src/jniapi.c
     ${PROJECT_SOURCE_DIR}/src/com_uber_h3core_NativeMethods.h)
 
 add_library(h3-java SHARED ${JNI_SOURCE_FILES})
-if(BUILD_SHARED_LIBS)
-    set_target_properties(h3 PROPERTIES SOVERSION ${H3_SOVERSION})
-endif()
-target_link_libraries(h3-java h3)
+target_link_libraries(h3-java ${H3_BUILD_ROOT}/lib/libh3${CMAKE_STATIC_LIBRARY_SUFFIX})
 
-# ENABLE_FORMAT is from ${H3_ROOT}/CMakeLists.txt
 find_program(CLANG_FORMAT_PATH clang-format)
 cmake_dependent_option(
     ENABLE_FORMAT "Enable running clang-format before compiling" ON
@@ -75,5 +70,3 @@ elseif(NOT CLANG_FORMAT_PATH)
     message(WARNING "clang-format was not detected, "
                     "so automatic source code reformatting is disabled.")
 endif()
-
-add_dependencies(h3-java h3)

--- a/src/main/c/h3-java/build-h3-docker.sh
+++ b/src/main/c/h3-java/build-h3-docker.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Arguments: [build-root]
+# build-root - Location to build the library.
+#
+# Builds H3 and H3-Java in the given directory. This is intended to be
+# called from build-h3.sh as part of the cross compilation process.
+
+set -ex
+
+BUILD_ROOT=$1
+
+cd $BUILD_ROOT
+
+mkdir -p build
+pushd build
+
+cmake -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    -DCMAKE_C_STANDARD_REQUIRED=ON \
+    -DCMAKE_C_STANDARD=11 \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DCMAKE_BUILD_TYPE=Release \
+    ../../h3
+make h3
+H3_BUILD_ROOT="$(pwd)"
+
+popd
+
+cmake -DBUILD_SHARED_LIBS=ON \
+    -DH3_SRC_ROOT=/work/target/h3 \
+    "-DH3_BUILD_ROOT=$H3_BUILD_ROOT" \
+    -DCMAKE_BUILD_TYPE=Release \
+    /work/src/main/c/h3-java
+make h3-java

--- a/src/main/c/h3-java/build-h3.sh
+++ b/src/main/c/h3-java/build-h3.sh
@@ -26,7 +26,7 @@
 # This script expects to be run from the project's base directory (where
 # pom.xml is) as part of the Maven build process.
 
-set -e
+set -ex
 
 GIT_REMOTE=$1
 GIT_REVISION=$2
@@ -51,22 +51,47 @@ H3_ROOT=`pwd`
 popd
 
 #
-# Now that H3 is downloaded, build H3-Java's native library and H3 along with
-# it.
+# Now that H3 is downloaded, build H3-Java's native library for this platform.
 #
 
 mkdir -p h3-java-build
 pushd h3-java-build
 
-cmake -DBUILD_SHARED_LIBS=ON "-DH3_ROOT=$H3_ROOT" -DCMAKE_BUILD_TYPE=Release ../../src/main/c/h3-java
+cmake -DUSE_NATIVE_JNI=ON -DBUILD_SHARED_LIBS=ON "-DH3_ROOT=$H3_ROOT" -DCMAKE_BUILD_TYPE=Release ../../src/main/c/h3-java
 make h3-java binding-functions
 
 popd
 popd
 
+# Copy the built artifact for this platform.
+if [ "$(uname -sm)" = "Darwin x86_64" ]; then
+    mkdir -p src/main/resources/darwin-x64
+    cp target/h3-java-build/lib/libh3-java.dylib src/main/resources/darwin-x64
+else
+    cp target/h3-java-build/lib/libh3-java* src/main/resources/
+fi
+
 #
-# Copy the built artifact into the source tree so it can be included in the
-# built JAR.
+# Now that H3 is downloaded, build H3-Java's native library for other platforms.
 #
 
-cp target/h3-java-build/lib/libh3* src/main/resources/
+# linux-armv6 excluded because of build failure
+for image in android-arm android-arm64 linux-arm64 linux-armv5 linux-armv7 linux-mipsel linux-mips linux-s390x linux-ppc64le linux-x64 linux-x86 windows-x64 windows-x86; do
+    # Setup for using dockcross
+    BUILD_ROOT=target/h3-java-build-$image
+    mkdir -p $BUILD_ROOT
+    docker pull dockcross/$image
+    docker run --rm dockcross/$image > $BUILD_ROOT/dockcross
+    chmod +x $BUILD_ROOT/dockcross
+
+    # Perform the actual build inside Docker
+    $BUILD_ROOT/dockcross --args "-v $JAVA_HOME:/java" bash -c "cd $BUILD_ROOT && cmake -DBUILD_SHARED_LIBS=ON -DH3_ROOT=/work/target/h3 -DCMAKE_BUILD_TYPE=Release /work/src/main/c/h3-java && make h3-java"
+
+    # Copy the built artifact into the source tree so it can be included in the
+    # built JAR.
+    OUTPUT_ROOT=src/main/resources/$image
+    mkdir -p $OUTPUT_ROOT
+    if [ -e $BUILD_ROOT/lib/libh3-java.so ]; then cp $BUILD_ROOT/lib/libh3-java.so $OUTPUT_ROOT ; fi
+    if [ -e $BUILD_ROOT/lib/libh3-java.dylib ]; then cp $BUILD_ROOT/lib/libh3-java.dylib $OUTPUT_ROOT ; fi
+    if [ -e $BUILD_ROOT/lib/libh3-java.dll ]; then cp $BUILD_ROOT/lib/libh3-java.dll $OUTPUT_ROOT ; fi
+done

--- a/src/main/java/com/uber/h3core/H3CoreLoader.java
+++ b/src/main/java/com/uber/h3core/H3CoreLoader.java
@@ -29,6 +29,9 @@ final class H3CoreLoader {
         // Prevent instantiation
     }
 
+    // Supported H3 architectures
+    private static final String ARCH_X64 = "x64";
+
     private static volatile File libraryFile = null;
 
     /**
@@ -77,8 +80,8 @@ final class H3CoreLoader {
         // loading the shared object at the same time, bad things could happen.
 
         if (libraryFile == null) {
-            OperatingSystem os = detectOs();
-            String arch = detectArch();
+            OperatingSystem os = detectOs(System.getProperty("java.vendor"), System.getProperty("os.name"));
+            String arch = detectArch(System.getProperty("os.arch"));
 
             String dirName = String.format("%s-%s", os.getDirName(), arch);
             String libName = String.format("libh3-java%s", os.getSuffix());
@@ -113,7 +116,7 @@ final class H3CoreLoader {
     /**
      * Operating systems supported by H3-Java.
      */
-    private enum OperatingSystem {
+    enum OperatingSystem {
         ANDROID(".so"),
         DARWIN(".dylib"),
         WINDOWS(".dll"),
@@ -142,15 +145,18 @@ final class H3CoreLoader {
 
     /**
      * Detect the current operating system.
+     *
+     * @param javaVendor Value of system property "java.vendor"
+     * @param osName Value of system property "os.name"
      */
-    private static final OperatingSystem detectOs() {
+    static final OperatingSystem detectOs(String javaVendor, String osName) {
         // Detecting Android using the properties from:
         // https://developer.android.com/reference/java/lang/System.html
-        if (System.getProperty("java.vendor").toLowerCase().contains("android")) {
+        if (javaVendor.toLowerCase().contains("android")) {
             return OperatingSystem.ANDROID;
         }
 
-        String javaOs = System.getProperty("os.name").toLowerCase();
+        String javaOs = osName.toLowerCase();
         if (javaOs.contains("mac")) {
             return OperatingSystem.DARWIN;
         } else if (javaOs.contains("win")) {
@@ -163,13 +169,14 @@ final class H3CoreLoader {
 
     /**
      * Detect the system architecture.
+     *
+     * @param osArch Value of system property "os.arch"
      */
-    private static final String detectArch() {
-        String javaArch = System.getProperty("os.arch");
-        if (javaArch.equals("amd64") || javaArch.equals("x86_64")) {
-            return "x64";
+    static final String detectArch(String osArch) {
+        if (osArch.equals("amd64") || osArch.equals("x86_64")) {
+            return ARCH_X64;
         } else {
-            return javaArch;
+            return osArch;
         }
     }
 }

--- a/src/test/java/com/uber/h3core/TestH3CoreLoader.java
+++ b/src/test/java/com/uber/h3core/TestH3CoreLoader.java
@@ -17,13 +17,41 @@ package com.uber.h3core;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+
 /**
- * H3CoreLoader is mostly tested by {@link TestH3Core}.
+ * H3CoreLoader is mostly tested by {@link TestH3Core}. This also tests OS detection.
  */
 public class TestH3CoreLoader {
     @Test
     public void testConstructor() {
         new H3CoreLoader();
         // Nothing else to test here
+    }
+
+    @Test
+    public void testDetectOs() {
+        assertEquals(H3CoreLoader.OperatingSystem.ANDROID,
+                H3CoreLoader.detectOs("Android", "anything"));
+        assertEquals(H3CoreLoader.OperatingSystem.DARWIN,
+                H3CoreLoader.detectOs("vendor", "Mac OS X"));
+        assertEquals(H3CoreLoader.OperatingSystem.WINDOWS,
+                H3CoreLoader.detectOs("vendor", "Windows"));
+        assertEquals(H3CoreLoader.OperatingSystem.LINUX,
+                H3CoreLoader.detectOs("vendor", "Linux"));
+
+        assertEquals(H3CoreLoader.OperatingSystem.LINUX,
+                H3CoreLoader.detectOs("vendor", "anything else"));
+    }
+
+    @Test
+    public void testDetectArch() {
+        assertEquals("x64", H3CoreLoader.detectArch("amd64"));
+        assertEquals("x64", H3CoreLoader.detectArch("x86_64"));
+        assertEquals("x64", H3CoreLoader.detectArch("x64"));
+
+        assertEquals("x86", H3CoreLoader.detectArch("x86"));
+
+        assertEquals("anything", H3CoreLoader.detectArch("anything"));
     }
 }


### PR DESCRIPTION
Uses dockcross to cross-compile from Mac or Linux to: Linux (various architectures), Android (arm/arm64), and Windows (x86/x64). Mac OSX is built only when it is the host build platform.

Change H3CoreLoader to detect Windows, Linux, etc. Its detection of architecture names is not complete right now.

Add OSX to Travis CI.

Fixes #3, but will require that built artifacts for Maven are built on a Mac, so that they contain the Darwin x64 binary. This can't be done in Travis because it does not support Docker on Mac.