### PR TITLE
Prepare for v3.0.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The public API of this library consists of the public functions declared in
 file [H3Core.java](./src/main/java/com/uber/h3core/H3Core.java).
 
-## [Unreleased]
+## [3.0.1] - 2018-04-30
 ### Added
+- Added release settings.
 - Added script for cross compiling using dockcross.
+### Changed
+- Updated the core library to v3.0.5.
 - Changed the native library loader to detect more operating systems.
 
 ## [3.0.0] - 2018-03-27

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/uber/h3-java.svg?branch=master)](https://travis-ci.org/uber/h3-java)
 [![Coverage Status](https://coveralls.io/repos/github/uber/h3-java/badge.svg?branch=master)](https://coveralls.io/github/uber/h3-java?branch=master)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.uber/h3/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.uber/h3)
 
 This library provides Java bindings for the [H3 Core Library](https://github.com/uber/h3). For API reference, please see the [H3 Documentation](https://uber.github.io/h3/).
 
@@ -14,14 +15,14 @@ Add it to your pom.xml:
 <dependency>
     <groupId>com.uber</groupId>
     <artifactId>h3</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
 </dependency>
 ```
 
 Or, using Gradle:
 
 ```gradle
-compile("com.uber:h3:3.0.0")
+compile("com.uber:h3:3.0.1")
 ```
 
 Encode a location into a hexagon address:

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>com.uber</groupId>
     <artifactId>h3</artifactId>
     <packaging>jar</packaging>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.1-SNAPSHOT</version>
     <name>h3</name>
     <url>https://github.com/uber/h3-java</url>
     <description>Java bindings for H3, a hierarchical hexagonal geospatial indexing system.</description>
@@ -68,7 +68,7 @@
         <org.openjdk.jmh.version>1.19</org.openjdk.jmh.version>
 
         <h3.git.remote>https://github.com/uber/h3.git</h3.git.remote>
-        <h3.git.reference>v3.0.3</h3.git.reference>
+        <h3.git.reference>v3.0.5</h3.git.reference>
         <h3.use.docker>true</h3.use.docker>
     </properties>
 


### PR DESCRIPTION
Bump core library to 3.0.5. Once this is merged, I'll do the release via the release instructions.