### PR TITLE
Add some aliases for x86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ for the Linux x64 and Darwin x64 platforms.
 ## Unreleased
 ### Fixed
 - Fixed memory management in polyfill with multiple holes.
+### Changed
+- Improve detection of x86 architecture.
 
 ## [3.0.1] - 2018-04-30
 ### Added

--- a/README.md
+++ b/README.md
@@ -49,11 +49,10 @@ H3-Java provides bindings to the H3 library, which is written in C. The built ar
 
 | Operating System | Architectures
 | ---------------- | -------------
-| Linux            | x64<sup>*</sup>, x86, ARM64, ARMv5, ARMv7, MIPS, MIPSEL, PPC64LE, s390x
+| Linux            | x64, x86, ARM64, ARMv5, ARMv7, MIPS, MIPSEL, PPC64LE, s390x
 | Windows          | x64, x86
-| Darwin (Mac OSX) | x64<sup>*</sup>
+| Darwin (Mac OSX) | x64
 | Android          | ARM, ARM64
-<em><sup>*</sup> Part of the semantic version of the library.</em>
 
 You may be able to build H3-Java locally if you need to use an operating system or architecture not listed above.
 

--- a/src/main/java/com/uber/h3core/H3CoreLoader.java
+++ b/src/main/java/com/uber/h3core/H3CoreLoader.java
@@ -31,6 +31,7 @@ final class H3CoreLoader {
 
     // Supported H3 architectures
     private static final String ARCH_X64 = "x64";
+    private static final String ARCH_X86 = "x86";
 
     private static volatile File libraryFile = null;
 
@@ -52,8 +53,9 @@ final class H3CoreLoader {
      *
      * @param resourcePath Resource to copy
      * @param newH3LibFile File to write
+     * @throws UnsatisfiedLinkError The resource path does not exist
      */
-    private static void copyResource(String resourcePath, File newH3LibFile) throws IOException {
+    static void copyResource(String resourcePath, File newH3LibFile) throws IOException {
         // Set the permissions
         newH3LibFile.setReadable(true);
         newH3LibFile.setWritable(true, true);
@@ -61,6 +63,10 @@ final class H3CoreLoader {
 
         // Shove the resource into the file and close it
         try (InputStream resource = H3CoreLoader.class.getResourceAsStream(resourcePath)) {
+            if (resource == null) {
+                throw new UnsatisfiedLinkError(String.format("No native resource found at %s", resource));
+            }
+
             try (FileOutputStream outFile = new FileOutputStream(newH3LibFile)) {
                 copyStream(resource, outFile);
             }
@@ -80,13 +86,13 @@ final class H3CoreLoader {
         // loading the shared object at the same time, bad things could happen.
 
         if (libraryFile == null) {
-            OperatingSystem os = detectOs(System.getProperty("java.vendor"), System.getProperty("os.name"));
-            String arch = detectArch(System.getProperty("os.arch"));
+            final OperatingSystem os = detectOs(System.getProperty("java.vendor"), System.getProperty("os.name"));
+            final String arch = detectArch(System.getProperty("os.arch"));
 
-            String dirName = String.format("%s-%s", os.getDirName(), arch);
-            String libName = String.format("libh3-java%s", os.getSuffix());
+            final String dirName = String.format("%s-%s", os.getDirName(), arch);
+            final String libName = String.format("libh3-java%s", os.getSuffix());
 
-            File newLibraryFile = File.createTempFile("libh3-java", os.getSuffix());
+            final File newLibraryFile = File.createTempFile("libh3-java", os.getSuffix());
 
             newLibraryFile.deleteOnExit();
 
@@ -175,6 +181,13 @@ final class H3CoreLoader {
     static final String detectArch(String osArch) {
         if (osArch.equals("amd64") || osArch.equals("x86_64")) {
             return ARCH_X64;
+        } else if (osArch.equals("i386") ||
+                   osArch.equals("i486") ||
+                   osArch.equals("i586") ||
+                   osArch.equals("i686") ||
+                   osArch.equals("i786") ||
+                   osArch.equals("i886")) {
+            return ARCH_X86;
         } else {
             return osArch;
         }

--- a/src/main/java/com/uber/h3core/H3CoreLoader.java
+++ b/src/main/java/com/uber/h3core/H3CoreLoader.java
@@ -30,8 +30,8 @@ final class H3CoreLoader {
     }
 
     // Supported H3 architectures
-    private static final String ARCH_X64 = "x64";
-    private static final String ARCH_X86 = "x86";
+    static final String ARCH_X64 = "x64";
+    static final String ARCH_X86 = "x86";
 
     private static volatile File libraryFile = null;
 

--- a/src/test/java/com/uber/h3core/TestH3CoreLoader.java
+++ b/src/test/java/com/uber/h3core/TestH3CoreLoader.java
@@ -62,7 +62,7 @@ public class TestH3CoreLoader {
         assertEquals("x86", H3CoreLoader.detectArch("i886"));
 
         assertEquals("anything", H3CoreLoader.detectArch("anything"));
-        assertEquals("i996", H3CoreLoader.detectArch("i996"));
+        assertEquals("i986", H3CoreLoader.detectArch("i986"));
         assertEquals("i286", H3CoreLoader.detectArch("i286"));
     }
 

--- a/src/test/java/com/uber/h3core/TestH3CoreLoader.java
+++ b/src/test/java/com/uber/h3core/TestH3CoreLoader.java
@@ -49,17 +49,17 @@ public class TestH3CoreLoader {
 
     @Test
     public void testDetectArch() {
-        assertEquals("x64", H3CoreLoader.detectArch("amd64"));
-        assertEquals("x64", H3CoreLoader.detectArch("x86_64"));
-        assertEquals("x64", H3CoreLoader.detectArch("x64"));
+        assertEquals(H3CoreLoader.ARCH_X64, H3CoreLoader.detectArch("amd64"));
+        assertEquals(H3CoreLoader.ARCH_X64, H3CoreLoader.detectArch("x86_64"));
+        assertEquals(H3CoreLoader.ARCH_X64, H3CoreLoader.detectArch("x64"));
 
-        assertEquals("x86", H3CoreLoader.detectArch("x86"));
-        assertEquals("x86", H3CoreLoader.detectArch("i386"));
-        assertEquals("x86", H3CoreLoader.detectArch("i486"));
-        assertEquals("x86", H3CoreLoader.detectArch("i586"));
-        assertEquals("x86", H3CoreLoader.detectArch("i686"));
-        assertEquals("x86", H3CoreLoader.detectArch("i786"));
-        assertEquals("x86", H3CoreLoader.detectArch("i886"));
+        assertEquals(H3CoreLoader.ARCH_X86, H3CoreLoader.detectArch("x86"));
+        assertEquals(H3CoreLoader.ARCH_X86, H3CoreLoader.detectArch("i386"));
+        assertEquals(H3CoreLoader.ARCH_X86, H3CoreLoader.detectArch("i486"));
+        assertEquals(H3CoreLoader.ARCH_X86, H3CoreLoader.detectArch("i586"));
+        assertEquals(H3CoreLoader.ARCH_X86, H3CoreLoader.detectArch("i686"));
+        assertEquals(H3CoreLoader.ARCH_X86, H3CoreLoader.detectArch("i786"));
+        assertEquals(H3CoreLoader.ARCH_X86, H3CoreLoader.detectArch("i886"));
 
         assertEquals("anything", H3CoreLoader.detectArch("anything"));
         assertEquals("i986", H3CoreLoader.detectArch("i986"));

--- a/src/test/java/com/uber/h3core/TestH3CoreLoader.java
+++ b/src/test/java/com/uber/h3core/TestH3CoreLoader.java
@@ -17,6 +17,9 @@ package com.uber.h3core;
 
 import org.junit.Test;
 
+import java.io.File;
+import java.io.IOException;
+
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -51,7 +54,24 @@ public class TestH3CoreLoader {
         assertEquals("x64", H3CoreLoader.detectArch("x64"));
 
         assertEquals("x86", H3CoreLoader.detectArch("x86"));
+        assertEquals("x86", H3CoreLoader.detectArch("i386"));
+        assertEquals("x86", H3CoreLoader.detectArch("i486"));
+        assertEquals("x86", H3CoreLoader.detectArch("i586"));
+        assertEquals("x86", H3CoreLoader.detectArch("i686"));
+        assertEquals("x86", H3CoreLoader.detectArch("i786"));
+        assertEquals("x86", H3CoreLoader.detectArch("i886"));
 
         assertEquals("anything", H3CoreLoader.detectArch("anything"));
+        assertEquals("i996", H3CoreLoader.detectArch("i996"));
+        assertEquals("i286", H3CoreLoader.detectArch("i286"));
+    }
+
+    @Test(expected = UnsatisfiedLinkError.class)
+    public void testExtractNonexistant() throws IOException {
+        File tempFile = File.createTempFile("test-extract-resource", null);
+
+        tempFile.deleteOnExit();
+
+        H3CoreLoader.copyResource("/nonexistant-resource", tempFile);
     }
 }


### PR DESCRIPTION
i386, i686, etc. should all be implemented by the x86 binary.

Also fixed up some text on README about supported platforms, since the library is using the uber/h3 version for it's major and minor version numbers.