### PR TITLE
Fix memory management in polyfill with multiple holes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The public API of this library consists of the public functions declared in
 file [H3Core.java](./src/main/java/com/uber/h3core/H3Core.java), and support
 for the Linux x64 and Darwin x64 platforms.
 
+## Unreleased
+### Fixed
+- Fixed memory management in polyfill with multiple holes.
+
 ## [3.0.1] - 2018-04-30
 ### Added
 - Added release settings.

--- a/src/main/c/h3-java/src/jniapi.c
+++ b/src/main/c/h3-java/src/jniapi.c
@@ -98,10 +98,10 @@ int CreateGeoPolygon(JNIEnv *env, jdoubleArray verts, jintArray holeSizes,
 
         size_t offset = 0;
         for (int i = 0; i < polygon->numHoles; i++) {
-            // This is the number of doubles, so convert to numver of verts
+            // This is the number of doubles, so convert to number of verts
             polygon->holes[i].numVerts = holeSizesElements[i] / 2;
             polygon->holes[i].verts = holeVertsElements + offset;
-            offset += holeSizesElements[i] * sizeof(double);
+            offset += holeSizesElements[i];
         }
 
         (**env).ReleaseIntArrayElements(env, holeSizes, holeSizesElements, 0);

--- a/src/test/java/com/uber/h3core/TestH3Core.java
+++ b/src/test/java/com/uber/h3core/TestH3Core.java
@@ -16,6 +16,7 @@
 package com.uber.h3core;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.uber.h3core.exceptions.PentagonEncounteredException;
 import com.uber.h3core.util.Vector2D;
 import org.junit.BeforeClass;
@@ -363,6 +364,23 @@ public class TestH3Core {
         );
 
         assertTrue(hexagons.size() > 1000);
+    }
+
+    @Test
+    public void testPolyfillKnownHoles() {
+        List<Long> inputHexagons = h3.kRing(0x85283083fffffffL, 2);
+        inputHexagons.remove(0x8528308ffffffffL);
+        inputHexagons.remove(0x85283097fffffffL);
+        inputHexagons.remove(0x8528309bfffffffL);
+
+        List<List<Vector2D>> geo = h3.h3SetToMultiPolygon(inputHexagons, true).get(0);
+
+        // TODO: looks like a bug in H3 that this is index 1
+        List<Vector2D> outline = geo.remove(1); // geo is now holes
+
+        List<Long> outputHexagons = h3.polyfill(outline, geo, 5);
+
+        assertEquals(ImmutableSet.copyOf(inputHexagons), ImmutableSet.copyOf(outputHexagons));
     }
 
     @Test


### PR DESCRIPTION
Multiple holes would not be correctly used because the C code would read past the end of the buffer. Setting up some tests with the C code would be helpful so that Valgrind could also be used.