### PR TITLE
Improve build on Linux without Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ matrix:
     - os: linux
       env: NAME="Linux without Docker"
       jdk: oraclejdk9
+      install:
+        - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dh3.use.docker=false
       script:
-        - mvn clean test -Dh3.use.docker=false
+        - mvn test -B -Dh3.use.docker=false
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,6 @@ matrix:
       jdk: openjdk8
     - os: linux
       jdk: oraclejdk9
+      script:
+        - mvn clean test -Dh3.use.docker=false
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ matrix:
     - os: linux
       jdk: openjdk8
     - os: linux
+      env: NAME="Linux without Docker"
       jdk: oraclejdk9
       script:
         - mvn clean test -Dh3.use.docker=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ for the Linux x64 and Darwin x64 platforms.
 ## Unreleased
 ### Fixed
 - Fixed memory management in polyfill with multiple holes.
+- Fixed build on Linux without Docker.
+### Changed
+- Improve detection of x86 architecture.
 
 ## [3.0.1] - 2018-04-30
 ### Added

--- a/src/main/c/h3-java/build-h3.sh
+++ b/src/main/c/h3-java/build-h3.sh
@@ -87,6 +87,11 @@ popd
 case "$(uname -sm)" in
     "Linux x86_64")  LIBRARY_DIR=linux-x64 ;;
     "Linux i386")    LIBRARY_DIR=linux-x86 ;;
+    "Linux i486")    LIBRARY_DIR=linux-x86 ;;
+    "Linux i586")    LIBRARY_DIR=linux-x86 ;;
+    "Linux i686")    LIBRARY_DIR=linux-x86 ;;
+    "Linux i786")    LIBRARY_DIR=linux-x86 ;;
+    "Linux i886")    LIBRARY_DIR=linux-x86 ;;
     "Darwin x86_64") LIBRARY_DIR=darwin-x64 ;;
     # TODO: Detect others
     *)               LIBRARY_DIR="" ;;

--- a/src/main/c/h3-java/build-h3.sh
+++ b/src/main/c/h3-java/build-h3.sh
@@ -45,7 +45,7 @@ if [ ! -d "h3" ]; then
 fi
 
 pushd h3
-git pull origin master --tags
+git fetch origin --tags
 
 echo Using revision "$GIT_REVISION"
 git checkout "$GIT_REVISION"
@@ -84,24 +84,27 @@ popd
 popd
 
 # Copy the built artifact for this platform.
-if [ "$(uname -sm)" = "Darwin x86_64" ]; then
-    mkdir -p src/main/resources/darwin-x64
-    cp target/h3-java-build/lib/libh3-java.dylib src/main/resources/darwin-x64
-else
-    # TODO: Detect which platform is being built on and copy to the correct directory.
-    cp target/h3-java-build/lib/libh3-java* src/main/resources/
-fi
+case "$(uname -sm)" in
+    "Linux x86_64")  LIBRARY_DIR=linux-x64 ;;
+    "Linux i386")    LIBRARY_DIR=linux-x86 ;;
+    "Darwin x86_64") LIBRARY_DIR=darwin-x64 ;;
+    # TODO: Detect others
+    *)               LIBRARY_DIR="" ;;
+esac
+
+mkdir -p src/main/resources/$LIBRARY_DIR
+cp target/h3-java-build/lib/libh3-java* src/main/resources/$LIBRARY_DIR
 
 #
 # Now that H3 is downloaded, build H3-Java's native library for other platforms.
 #
 
-if ! command -v docker; then
-    echo Docker not found, skipping cross compilation.
-    exit 0
-fi
 if ! $USE_DOCKER; then
     echo Docker disabled, skipping cross compilation.
+    exit 0
+fi
+if ! command -v docker; then
+    echo Docker not found, skipping cross compilation.
     exit 0
 fi
 

--- a/src/main/java/com/uber/h3core/H3CoreLoader.java
+++ b/src/main/java/com/uber/h3core/H3CoreLoader.java
@@ -61,6 +61,10 @@ final class H3CoreLoader {
 
         // Shove the resource into the file and close it
         try (InputStream resource = H3CoreLoader.class.getResourceAsStream(resourcePath)) {
+            if (resource == null) {
+                throw new UnsatisfiedLinkError(String.format("No native resource found at %s", resourcePath));
+            }
+
             try (FileOutputStream outFile = new FileOutputStream(newH3LibFile)) {
                 copyStream(resource, outFile);
             }


### PR DESCRIPTION
Update the build script to move the library into place for Linux x86 and x64 even when Docker is not available. Changes one of the Travis jobs to test this path.