### PR TITLE
Add newInstance that accepts OS and Arch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ for the Linux x64 and Darwin x64 platforms.
 ## [Unreleased]
 ### Added
 - `h3Distance` function. (#21)
-- `newInstance` override that accepts specific operating system and architecture values.
+- `newInstance` override that accepts specific operating system and architecture values. (#24)
 ### Changed
 - Updated the core library to v3.1.0. (#21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ for the Linux x64 and Darwin x64 platforms.
 ## [Unreleased]
 ### Added
 - `h3Distance` function. (#21)
+- `newInstance` override that accepts specific operating system and architecture values.
 ### Changed
 - Updated the core library to v3.1.0. (#21)
 

--- a/src/main/c/h3-java/CMakeLists.txt
+++ b/src/main/c/h3-java/CMakeLists.txt
@@ -51,6 +51,11 @@ set(JNI_SOURCE_FILES
 add_library(h3-java SHARED ${JNI_SOURCE_FILES})
 target_link_libraries(h3-java ${H3_BUILD_ROOT}/lib/libh3${CMAKE_STATIC_LIBRARY_SUFFIX})
 
+find_library(M_LIB m)
+if(M_LIB)
+    target_link_libraries(h3-java ${M_LIB})
+endif()
+
 find_program(CLANG_FORMAT_PATH clang-format)
 cmake_dependent_option(
     ENABLE_FORMAT "Enable running clang-format before compiling" ON

--- a/src/main/java/com/uber/h3core/H3Core.java
+++ b/src/main/java/com/uber/h3core/H3Core.java
@@ -59,6 +59,8 @@ public class H3Core {
 
     /**
      * Create by unpacking the H3 native library to disk and loading it.
+     * The library will attempt to detect the correct operating system
+     * and architecture of native library to unpack.
      *
      * @throws SecurityException Loading the library was not allowed by the
      *                           SecurityManager.
@@ -67,6 +69,21 @@ public class H3Core {
      */
     public static H3Core newInstance() throws IOException {
         NativeMethods h3Api = H3CoreLoader.loadNatives();
+        return new H3Core(h3Api);
+    }
+
+    /**
+     * Create by unpacking the H3 native library to disk and loading it.
+     * The library will attempt to extract the native library matching
+     * the given arguments to disk.
+     *
+     * @throws SecurityException Loading the library was not allowed by the
+     *                           SecurityManager.
+     * @throws UnsatisfiedLinkError The library could not be loaded
+     * @throws IOException The library could not be extracted to disk.
+     */
+    public static H3Core newInstance(H3CoreLoader.OperatingSystem os, String arch) throws IOException {
+        NativeMethods h3Api = H3CoreLoader.loadNatives(os, arch);
         return new H3Core(h3Api);
     }
 

--- a/src/main/java/com/uber/h3core/H3CoreLoader.java
+++ b/src/main/java/com/uber/h3core/H3CoreLoader.java
@@ -32,6 +32,7 @@ final class H3CoreLoader {
     // Supported H3 architectures
     static final String ARCH_X64 = "x64";
     static final String ARCH_X86 = "x86";
+    static final String ARCH_ARM64 = "arm64";
 
     private static volatile File libraryFile = null;
 
@@ -81,14 +82,34 @@ final class H3CoreLoader {
      * @throws UnsatisfiedLinkError The library could not be loaded
      * @throws IOException Failed to unpack the library
      */
-    public synchronized static NativeMethods loadNatives() throws IOException {
+    public static NativeMethods loadNatives() throws IOException {
+        final OperatingSystem os = detectOs(System.getProperty("java.vendor"), System.getProperty("os.name"));
+        final String arch = detectArch(System.getProperty("os.arch"));
+
+        return loadNatives(os, arch);
+    }
+
+    /**
+     * For use when the H3 library should be unpacked from the JAR and loaded.
+     * The native library for the specified operating system and architecture
+     * will be extract.
+     *
+     * <p>H3 will only successfully extract the library once, even if different
+     * operating system and architecture are specified, or if {@link #loadNatives()}
+     * was used instead.
+     *
+     * @throws SecurityException Loading the library was not allowed by the
+     *                           SecurityManager.
+     * @throws UnsatisfiedLinkError The library could not be loaded
+     * @throws IOException Failed to unpack the library
+     * @param os Operating system whose lobrary should be used
+     * @param arch Architecture name, as packaged in the H3 library
+     */
+    public synchronized static NativeMethods loadNatives(OperatingSystem os, String arch) throws IOException {
         // This is synchronized because if multiple threads were writing and
         // loading the shared object at the same time, bad things could happen.
 
         if (libraryFile == null) {
-            final OperatingSystem os = detectOs(System.getProperty("java.vendor"), System.getProperty("os.name"));
-            final String arch = detectArch(System.getProperty("os.arch"));
-
             final String dirName = String.format("%s-%s", os.getDirName(), arch);
             final String libName = String.format("libh3-java%s", os.getSuffix());
 
@@ -122,7 +143,7 @@ final class H3CoreLoader {
     /**
      * Operating systems supported by H3-Java.
      */
-    enum OperatingSystem {
+    public enum OperatingSystem {
         ANDROID(".so"),
         DARWIN(".dylib"),
         WINDOWS(".dll"),
@@ -188,6 +209,8 @@ final class H3CoreLoader {
                    osArch.equals("i786") ||
                    osArch.equals("i886")) {
             return ARCH_X86;
+        } else if (osArch.equals("aarch64")) {
+            return ARCH_ARM64;
         } else {
             return osArch;
         }

--- a/src/main/java/com/uber/h3core/H3CoreLoader.java
+++ b/src/main/java/com/uber/h3core/H3CoreLoader.java
@@ -24,7 +24,7 @@ import java.io.OutputStream;
 /**
  * Extracts the native H3 core library to the local filesystem and loads it.
  */
-final class H3CoreLoader {
+public final class H3CoreLoader {
     H3CoreLoader() {
         // Prevent instantiation
     }

--- a/src/test/java/com/uber/h3core/TestH3Core.java
+++ b/src/test/java/com/uber/h3core/TestH3Core.java
@@ -50,9 +50,22 @@ public class TestH3Core {
         assertNotNull(h3);
 
         H3Core another = H3Core.newInstance();
+        assertNotNull(another);
 
         // Doesn't override equals.
         assertNotEquals(h3, another);
+    }
+
+    @Test
+    public void testConstructSpecific() throws IOException {
+        // This uses the same logic as H3CoreLoader for detecting
+        // the OS and architecture, to avoid issues with CI.
+        final H3CoreLoader.OperatingSystem os = H3CoreLoader.detectOs(System.getProperty("java.vendor"), System.getProperty("os.name"));
+        final String arch = H3CoreLoader.detectArch(System.getProperty("os.arch"));
+
+        H3Core another = H3Core.newInstance(os, arch);
+
+        assertNotNull(another);
     }
 
     @Test

--- a/src/test/java/com/uber/h3core/TestH3CoreLoader.java
+++ b/src/test/java/com/uber/h3core/TestH3CoreLoader.java
@@ -61,6 +61,9 @@ public class TestH3CoreLoader {
         assertEquals(H3CoreLoader.ARCH_X86, H3CoreLoader.detectArch("i786"));
         assertEquals(H3CoreLoader.ARCH_X86, H3CoreLoader.detectArch("i886"));
 
+        assertEquals(H3CoreLoader.ARCH_ARM64, H3CoreLoader.detectArch("arm64"));
+        assertEquals(H3CoreLoader.ARCH_ARM64, H3CoreLoader.detectArch("aarch64"));
+
         assertEquals("anything", H3CoreLoader.detectArch("anything"));
         assertEquals("i986", H3CoreLoader.detectArch("i986"));
         assertEquals("i286", H3CoreLoader.detectArch("i286"));


### PR DESCRIPTION
This is to be used as an escape hatch in case the default detection
logic isn't able to correctly identify the architecture, and installing
the native library isn't feasible.

Add an architecture alias for `aarch64` -> `arm64` (needs testing.)

Relates to #23