### PR TITLE
Don't require a C++ compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The public API of this library consists of the public functions declared in
 file [H3Core.java](./src/main/java/com/uber/h3core/H3Core.java), and support
 for the Linux x64 and Darwin x64 platforms.
 
+## [Unreleased]
+### Fixed
+- Don't require a C++ compiler.
+
 ## [3.1.0] - 2018-10-04
 ### Added
 - `h3Distance` function. (#21)

--- a/src/main/c/h3-java/CMakeLists.txt
+++ b/src/main/c/h3-java/CMakeLists.txt
@@ -29,7 +29,7 @@ set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cmake/toolchain.cmake"
 set(LIBRARY_OUTPUT_PATH lib)
 set(H3_SOVERSION 1)
 
-project(h3-java)
+project(h3-java LANGUAGES C)
 
 include_directories(${H3_SRC_ROOT}/src/h3lib/include)
 


### PR DESCRIPTION
Same idea as uber/h3#107, C++ is not used in the JNI code so there's no reason to look for a C++ compiler.

Appveyor is expected to fail since #26 isn't merged yet.