### PR TITLE
Upgrade to v3.2.0, add local IJ functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ for the Linux x64 and Darwin x64 platforms.
 ## [Unreleased]
 ### Added
 - Support for building on Windows. (#26)
+- `experimentalH3ToLocalIj` and `experimentalLocalIjToH3` functions. (#32)
+### Changed
+- Updated the core library to v3.2.0. (#32)
 ### Fixed
 - Don't require a C++ compiler. (#30)
 

--- a/h3version.properties
+++ b/h3version.properties
@@ -1,1 +1,1 @@
-h3.git.reference=v3.1.1
+h3.git.reference=v3.2.0

--- a/src/main/c/h3-java/src/jniapi.c
+++ b/src/main/c/h3-java/src/jniapi.c
@@ -343,6 +343,61 @@ JNIEXPORT jint JNICALL Java_com_uber_h3core_NativeMethods_h3Distance(
 
 /*
  * Class:     com_uber_h3core_NativeMethods
+ * Method:    experimentalH3ToLocalIj
+ * Signature: (JJ[I)I
+ */
+JNIEXPORT int JNICALL
+Java_com_uber_h3core_NativeMethods_experimentalH3ToLocalIj(
+    JNIEnv *env, jobject thiz, jlong origin, jlong h3, jintArray coords) {
+    CoordIJ ij = {0};
+    int result = experimentalH3ToLocalIj(origin, h3, &ij);
+    if (result != 0) {
+        return result;
+    }
+
+    jsize sz = (**env).GetArrayLength(env, coords);
+    jint *coordsElements = (**env).GetIntArrayElements(env, coords, 0);
+
+    if (coordsElements != NULL) {
+        // if sz is too small, we will fail to write all the elements
+        if (sz >= 2) {
+            coordsElements[0] = ij.i;
+            coordsElements[1] = ij.j;
+        }
+
+        // 0 is the mode
+        // reference
+        // https://developer.android.com/training/articles/perf-jni.html
+        (**env).ReleaseIntArrayElements(env, coords, coordsElements, 0);
+        return 0;
+    } else {
+        ThrowOutOfMemoryError(env);
+        return -1;
+    }
+}
+
+/*
+ * Class:     com_uber_h3core_NativeMethods
+ * Method:    experimentalLocalIjToH3
+ * Signature: (JII)J
+ */
+JNIEXPORT jlong JNICALL
+Java_com_uber_h3core_NativeMethods_experimentalLocalIjToH3(JNIEnv *env,
+                                                           jobject thiz,
+                                                           jlong origin, jint i,
+                                                           jint j) {
+    CoordIJ ij = {.i = i, .j = j};
+    H3Index index;
+    int result = experimentalLocalIjToH3(origin, &ij, &index);
+    if (result != 0) {
+        // Exact error is not preserved, just that the operation failed.
+        return 0;
+    }
+    return index;
+}
+
+/*
+ * Class:     com_uber_h3core_NativeMethods
  * Method:    maxPolyfillSize
  * Signature: ([D[I[DI)I
  */

--- a/src/main/java/com/uber/h3core/H3Core.java
+++ b/src/main/java/com/uber/h3core/H3Core.java
@@ -16,7 +16,9 @@
 package com.uber.h3core;
 
 import com.uber.h3core.exceptions.DistanceUndefinedException;
+import com.uber.h3core.exceptions.LocalIjUndefinedException;
 import com.uber.h3core.exceptions.PentagonEncounteredException;
+import com.uber.h3core.util.CoordIJ;
 import com.uber.h3core.util.GeoCoord;
 
 import java.io.IOException;
@@ -459,6 +461,107 @@ public class H3Core {
         }
 
         return distance;
+    }
+
+    /**
+     * Converts <code>h3</code> to IJ coordinates in a local coordinate space defined by
+     * <code>origin</code>.
+     *
+     * <p>The local IJ coordinate space may have deleted regions and warping due to pentagon
+     * distortion. IJ coordinates are only comparable if they came from the same origin.
+     *
+     * <p>This function is experimental, and its output is not guaranteed
+     * to be compatible across different versions of H3.
+     *
+     * @param origin Anchoring index for the local coordinate space.
+     * @param h3 Index to find the coordinates of.
+     * @return Coordinates for <code>h3</code> in the local coordinate space.
+     * @throws IllegalArgumentException The two indexes are not comparable.
+     * @throws PentagonEncounteredException The two indexes are separated by pentagonal distortion.
+     * @throws LocalIjUndefinedException The two indexes are too far apart.
+     */
+    public CoordIJ experimentalH3ToLocalIj(long origin, long h3) throws PentagonEncounteredException, LocalIjUndefinedException {
+        final int[] coords = new int[2];
+        final int result = h3Api.experimentalH3ToLocalIj(origin, h3, coords);
+        if (result != 0) {
+            switch (result) {
+                case 1:
+                    throw new IllegalArgumentException("Incompatible origin and index.");
+                default:
+                case 2:
+                    throw new LocalIjUndefinedException("Local IJ coordinates undefined for this origin and index pair (index may be too far from origin.)");
+                case 3:
+                case 4:
+                case 5:
+                    throw new PentagonEncounteredException("Encountered possible pentagon distortion");
+            }
+        }
+        return new CoordIJ(coords[0], coords[1]);
+    }
+
+    /**
+     * Converts <code>h3Address</code> to IJ coordinates in a local coordinate space defined by
+     * <code>originAddress</code>.
+     *
+     * <p>The local IJ coordinate space may have deleted regions and warping due to pentagon
+     * distortion. IJ coordinates are only comparable if they came from the same origin.
+     *
+     * <p>This function is experimental, and its output is not guaranteed
+     * to be compatible across different versions of H3.
+     *
+     * @param originAddress Anchoring index for the local coordinate space.
+     * @param h3Address Index to find the coordinates of.
+     * @return Coordinates for <code>h3</code> in the local coordinate space.
+     * @throws IllegalArgumentException The two indexes are not comparable.
+     * @throws PentagonEncounteredException The two indexes are separated by pentagonal distortion.
+     * @throws LocalIjUndefinedException The two indexes are too far apart.
+     */
+    public CoordIJ experimentalH3ToLocalIj(String originAddress, String h3Address) throws PentagonEncounteredException, LocalIjUndefinedException {
+        return experimentalH3ToLocalIj(stringToH3(originAddress), stringToH3(h3Address));
+    }
+
+    /**
+     * Converts the IJ coordinates to an index, using a local IJ coordinate space anchored by
+     * <code>origin</code>.
+     *
+     * <p>The local IJ coordinate space may have deleted regions and warping due to pentagon
+     * distortion. IJ coordinates are only comparable if they came from the same origin.
+     *
+     * <p>This function is experimental, and its output is not guaranteed
+     * to be compatible across different versions of H3.
+     *
+     * @param origin Anchoring index for the local coordinate space.
+     * @param ij Coordinates in the local IJ coordinate space.
+     * @return Index represented by <code>ij</code>
+     * @throws LocalIjUndefinedException No index is defined at the given location, for example
+     * because the coordinates are too far away from the origin, or pentagon distortion is encountered.
+     */
+    public long experimentalLocalIjToH3(long origin, CoordIJ ij) throws LocalIjUndefinedException {
+        final long result = h3Api.experimentalLocalIjToH3(origin, ij.i, ij.j);
+        if (result == 0) {
+            throw new LocalIjUndefinedException("Index not defined for this origin and IJ coordinates pair. IJ coordinates may be too far from origin, or pentagon distortion was encountered.");
+        }
+        return result;
+    }
+
+    /**
+     * Converts the IJ coordinates to an index, using a local IJ coordinate space anchored by
+     * <code>origin</code>.
+     *
+     * <p>The local IJ coordinate space may have deleted regions and warping due to pentagon
+     * distortion. IJ coordinates are only comparable if they came from the same origin.
+     *
+     * <p>This function is experimental, and its output is not guaranteed
+     * to be compatible across different versions of H3.
+     *
+     * @param originAddress Anchoring index for the local coordinate space.
+     * @param ij Coordinates in the local IJ coordinate space.
+     * @return Index represented by <code>ij</code>
+     * @throws LocalIjUndefinedException No index is defined at the given location, for example
+     * because the coordinates are too far away from the origin, or pentagon distortion is encountered.
+     */
+    public String experimentalLocalIjToH3(String originAddress, CoordIJ ij) throws LocalIjUndefinedException {
+        return h3ToString(experimentalLocalIjToH3(stringToH3(originAddress), ij));
     }
 
     /**

--- a/src/main/java/com/uber/h3core/H3Core.java
+++ b/src/main/java/com/uber/h3core/H3Core.java
@@ -483,20 +483,21 @@ public class H3Core {
     public CoordIJ experimentalH3ToLocalIj(long origin, long h3) throws PentagonEncounteredException, LocalIjUndefinedException {
         final int[] coords = new int[2];
         final int result = h3Api.experimentalH3ToLocalIj(origin, h3, coords);
-        if (result != 0) {
-            switch (result) {
-                case 1:
-                    throw new IllegalArgumentException("Incompatible origin and index.");
-                default:
-                case 2:
-                    throw new LocalIjUndefinedException("Local IJ coordinates undefined for this origin and index pair (index may be too far from origin.)");
-                case 3:
-                case 4:
-                case 5:
-                    throw new PentagonEncounteredException("Encountered possible pentagon distortion");
-            }
+        // The definition of these cases is in experimentalH3ToLocalIj in localij.c in the C library.
+        // 0 is success, anything else is a failure of some kind.
+        switch (result) {
+            case 0:
+                return new CoordIJ(coords[0], coords[1]);
+            case 1:
+                throw new IllegalArgumentException("Incompatible origin and index.");
+            default:
+            case 2:
+                throw new LocalIjUndefinedException("Local IJ coordinates undefined for this origin and index pair. The index may be too far from the origin.");
+            case 3:
+            case 4:
+            case 5:
+                throw new PentagonEncounteredException("Encountered possible pentagon distortion");
         }
-        return new CoordIJ(coords[0], coords[1]);
     }
 
     /**

--- a/src/main/java/com/uber/h3core/NativeMethods.java
+++ b/src/main/java/com/uber/h3core/NativeMethods.java
@@ -15,6 +15,7 @@
  */
 package com.uber.h3core;
 
+import com.uber.h3core.util.CoordIJ;
 import com.uber.h3core.util.GeoCoord;
 
 import java.util.ArrayList;
@@ -46,6 +47,8 @@ final class NativeMethods {
     native int hexRing(long h3, int k, long[] results);
 
     native int h3Distance(long a, long b);
+    native int experimentalH3ToLocalIj(long origin, long h3, int[] coords);
+    native long experimentalLocalIjToH3(long origin, int i, int j);
 
     native int maxPolyfillSize(double[] verts, int[] holeSizes, double[] holeVerts, int res);
     native void polyfill(double[] verts, int[] holeSizes, double[] holeVerts, int res, long[] results);

--- a/src/main/java/com/uber/h3core/exceptions/LocalIjUndefinedException.java
+++ b/src/main/java/com/uber/h3core/exceptions/LocalIjUndefinedException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.h3core.exceptions;
+
+/**
+ * The local IJ coordinates could not be determined for an index, or the
+ * index could not be determined for IJ coordinates.
+ *
+ * <p>This can happen because the origin and index/IJ coordinates are too
+ * far away from each other, or because pentagon distortion was encountered.
+ */
+public class LocalIjUndefinedException extends Exception {
+    public LocalIjUndefinedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/uber/h3core/util/CoordIJ.java
+++ b/src/main/java/com/uber/h3core/util/CoordIJ.java
@@ -1,0 +1,38 @@
+
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ */
+package com.uber.h3core.util;
+
+import java.util.Objects;
+
+/**
+ * Immutable two-dimensional IJ grid coordinates.
+ */
+public class CoordIJ {
+    public final int i;
+    public final int j;
+
+    public CoordIJ(int i, int j) {
+        this.i = i;
+        this.j = j;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CoordIJ ij = (CoordIJ) o;
+        return ij.i == i && ij.j == j;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(i, j);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("CoordIJ{i=%d, j=%d}", i, j);
+    }
+}

--- a/src/main/java/com/uber/h3core/util/CoordIJ.java
+++ b/src/main/java/com/uber/h3core/util/CoordIJ.java
@@ -1,6 +1,17 @@
-
 /*
- * Copyright (c) 2018 Uber Technologies, Inc.
+ * Copyright 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.uber.h3core.util;
 

--- a/src/test/java/com/uber/h3core/util/TestCoordIJ.java
+++ b/src/test/java/com/uber/h3core/util/TestCoordIJ.java
@@ -1,6 +1,17 @@
-
 /*
- * Copyright (c) 2018 Uber Technologies, Inc.
+ * Copyright 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.uber.h3core.util;
 

--- a/src/test/java/com/uber/h3core/util/TestCoordIJ.java
+++ b/src/test/java/com/uber/h3core/util/TestCoordIJ.java
@@ -1,0 +1,49 @@
+
+/*
+ * Copyright (c) 2018 Uber Technologies, Inc.
+ */
+package com.uber.h3core.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ *
+ */
+public class TestCoordIJ {
+    @Test
+    public void test() {
+        CoordIJ ij1 = new CoordIJ(0, 0);
+        CoordIJ ij2 = new CoordIJ(1, 10);
+        CoordIJ ij3 = new CoordIJ(0, 0);
+
+        assertEquals(0, ij1.i);
+        assertEquals(0, ij1.j);
+        assertEquals(1, ij2.i);
+        assertEquals(10, ij2.j);
+        assertEquals(0, ij3.i);
+        assertEquals(0, ij3.j);
+
+        assertNotEquals(ij1, ij2);
+        assertNotEquals(ij3, ij2);
+        assertEquals(ij1, ij3);
+        assertEquals(ij1, ij1);
+        assertNotEquals(ij1, null);
+
+        assertEquals(ij1.hashCode(), ij3.hashCode());
+        // Not strictly needed, but likely
+        assertNotEquals(ij1.hashCode(), ij2.hashCode());
+    }
+
+    @Test
+    public void testToString() {
+        CoordIJ ij = new CoordIJ(123, -456);
+
+        String toString = ij.toString();
+        assertTrue(toString.contains("i=123"));
+        assertTrue(toString.contains("j=-456"));
+    }
+}

--- a/src/test/java/com/uber/h3core/util/TestGeoCoord.java
+++ b/src/test/java/com/uber/h3core/util/TestGeoCoord.java
@@ -15,6 +15,7 @@
  */
 package com.uber.h3core.util;
 
+import com.uber.h3core.TestH3Core;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -31,11 +32,18 @@ public class TestGeoCoord {
         GeoCoord v2 = new GeoCoord(1, 0);
         GeoCoord v3 = new GeoCoord(0, 1);
 
-        assertNotEquals(null, v1);
-        assertNotEquals(0, v1);
+        assertEquals(0, v1.lat, TestH3Core.EPSILON);
+        assertEquals(1, v1.lng, TestH3Core.EPSILON);
+        assertEquals(1, v2.lat, TestH3Core.EPSILON);
+        assertEquals(0, v2.lng, TestH3Core.EPSILON);
+        assertEquals(0, v3.lat, TestH3Core.EPSILON);
+        assertEquals(1, v3.lng, TestH3Core.EPSILON);
+
         assertNotEquals(v1, v2);
         assertNotEquals(v3, v2);
         assertEquals(v1, v3);
+        assertEquals(v1, v1);
+        assertNotEquals(v1, null);
 
         assertEquals(v1.hashCode(), v3.hashCode());
         // Not strictly needed, but likely


### PR DESCRIPTION
Fixes uber/h3#99. 

`experimentalH3ToLocalIj` has some unusual error checking for the H3-Java library in that it attempts to translate the opaque error codes from the core library to more specific exceptions. However, this wasn't consistently done to `experimentalLocalIjToH3` as passing back the error code is not quite as easy. If we want to prioritize consistency, the easiest change would be for `experimentalH3ToLocalIj` to just throw `LocalIjUndefinedException` in all failure cases. Alternately, we could change `experimentalLocalIjToH3` to also have this (pass the index by reference.)