### PR TITLE
Test H3Core.newSystemInstance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
       env: NAME="Coverage report"
       jdk: oraclejdk8
       script:
-        - mvn clean test jacoco:report coveralls:report
+        - mvn clean test jacoco:report coveralls:report -Dh3.test.system=true -DargLine="-Djava.library.path=./src/main/resources/linux-x64/"
     - os: linux
       jdk: openjdk8
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
       env: NAME="Coverage report"
       jdk: oraclejdk8
       script:
-        - mvn clean test jacoco:report coveralls:report -Dh3.test.system=true -DargLine="-Djava.library.path=./src/main/resources/linux-x64/"
+        - mvn clean test jacoco:report coveralls:report -Dh3.test.system=true -Dh3.additional.argLine="-Djava.library.path=./src/main/resources/linux-x64/"
     - os: linux
       jdk: openjdk8
     - os: linux

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,10 @@
 
         <h3.git.remote>https://github.com/uber/h3.git</h3.git.remote>
         <h3.use.docker>true</h3.use.docker>
+        <!-- Used for passing additional arguments to surefire when using JaCoCo -->
+        <h3.additional.argLine></h3.additional.argLine>
+
+        <argLine>${h3.additional.argLine}</argLine>
     </properties>
 
     <profiles>

--- a/src/test/java/com/uber/h3core/TestH3CoreSystemInstance.java
+++ b/src/test/java/com/uber/h3core/TestH3CoreSystemInstance.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.h3core;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Test that {@see H3Core.newSystemInstance} can load the H3 library. This test is only
+ * run if the system property <code>h3.test.system</code> has the value <code>true</code>.
+ * It is expected that when running this test, the JVM has been setup to find the native
+ * library, either by installing it in a place it can be found, or setting the
+ * <code>java.library.path</code> system property before starting the test JVM.
+ */
+public class TestH3CoreSystemInstance {
+    @Test
+    public void test() {
+        if ("true".equals(System.getProperty("h3.test.system"))) {
+            final H3Core h3 = H3Core.newSystemInstance();
+            assertNotNull(h3);
+            assertEquals("84194adffffffff", h3.geoToH3Address(51.5008796,-0.1253643, 4));
+        }
+    }
+}

--- a/src/test/java/com/uber/h3core/TestH3CoreSystemInstance.java
+++ b/src/test/java/com/uber/h3core/TestH3CoreSystemInstance.java
@@ -15,10 +15,12 @@
  */
 package com.uber.h3core;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * Test that {@see H3Core.newSystemInstance} can load the H3 library. This test is only
@@ -28,12 +30,16 @@ import static org.junit.Assert.assertNotNull;
  * <code>java.library.path</code> system property before starting the test JVM.
  */
 public class TestH3CoreSystemInstance {
+    @BeforeClass
+    public static void assumptions() {
+        assumeTrue("System instance tests enabled",
+                "true".equals(System.getProperty("h3.test.system")));
+    }
+
     @Test
     public void test() {
-        if ("true".equals(System.getProperty("h3.test.system"))) {
-            final H3Core h3 = H3Core.newSystemInstance();
-            assertNotNull(h3);
-            assertEquals("84194adffffffff", h3.geoToH3Address(51.5008796,-0.1253643, 4));
-        }
+        final H3Core h3 = H3Core.newSystemInstance();
+        assertNotNull(h3);
+        assertEquals("84194adffffffff", h3.geoToH3Address(51.5008796, -0.1253643, 4));
     }
 }


### PR DESCRIPTION
`java.library.path` can't be set using `System.setProperty` from the test code, so this test can only be run if the test JVM was started with the library paths set correctly. To prevent this from failing most tests, `h3.test.system` must be set to `true` for this test to run.