### PR TITLE
Remove unneeded private ctor test, add tests for a few more branches

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.1</version>
+                <version>0.8.3</version>
                 <executions>
                     <execution>
                         <id>jacoco-instrument</id>

--- a/src/main/java/com/uber/h3core/H3Core.java
+++ b/src/main/java/com/uber/h3core/H3Core.java
@@ -702,7 +702,6 @@ public class H3Core {
      * @throws IllegalArgumentException <code>res</code> is not between 0 and the resolution of <code>h3</code>, inclusive.
      */
     public long h3ToParent(long h3, int res) {
-        checkResolution(res);
         // This is a ported version of h3ToParent from h3core.
 
         int childRes = (int) ((h3 & H3_RES_MASK) >> H3_RES_OFFSET);

--- a/src/main/java/com/uber/h3core/H3CoreLoader.java
+++ b/src/main/java/com/uber/h3core/H3CoreLoader.java
@@ -25,7 +25,7 @@ import java.io.OutputStream;
  * Extracts the native H3 core library to the local filesystem and loads it.
  */
 public final class H3CoreLoader {
-    H3CoreLoader() {
+    private H3CoreLoader() {
         // Prevent instantiation
     }
 

--- a/src/main/java/com/uber/h3core/NativeMethods.java
+++ b/src/main/java/com/uber/h3core/NativeMethods.java
@@ -27,7 +27,7 @@ import java.util.List;
  */
 final class NativeMethods {
     NativeMethods() {
-        // Prevent instantiation
+        // Only H3CoreLoader is expected to instantiate
     }
 
     native int maxH3ToChildrenSize(long h3, int childRes);

--- a/src/test/java/com/uber/h3core/TestH3Core.java
+++ b/src/test/java/com/uber/h3core/TestH3Core.java
@@ -587,6 +587,15 @@ public class TestH3Core {
     }
 
     @Test
+    public void testHexRingSingle() throws PentagonEncounteredException {
+        String origin = "8928308280fffff";
+        List<String> hexagons = h3.hexRing(origin, 0);
+
+        assertEquals(1, hexagons.size());
+        assertEquals("8928308280fffff", hexagons.get(0));
+    }
+
+    @Test
     public void testHostileInput() {
         assertNotEquals(0, h3.geoToH3(-987654321, 987654321, 5));
         assertNotEquals(0, h3.geoToH3(987654321, -987654321, 5));

--- a/src/test/java/com/uber/h3core/TestH3CoreLoader.java
+++ b/src/test/java/com/uber/h3core/TestH3CoreLoader.java
@@ -27,12 +27,6 @@ import static org.junit.Assert.assertEquals;
  */
 public class TestH3CoreLoader {
     @Test
-    public void testConstructor() {
-        new H3CoreLoader();
-        // Nothing else to test here
-    }
-
-    @Test
     public void testDetectOs() {
         assertEquals(H3CoreLoader.OperatingSystem.ANDROID,
                 H3CoreLoader.detectOs("Android", "anything"));


### PR DESCRIPTION
https://github.com/jacoco/jacoco/pull/529 has made tests for empty private constructors unnecessary, so that is removed. Based on the JaCoCo report I also added tests for a few uncovered branches.