### PR TITLE
Update to v3.4.2, add getRes0Indexes

### DIFF
--- a/h3version.properties
+++ b/h3version.properties
@@ -1,1 +1,1 @@
-h3.git.reference=v3.3.0
+h3.git.reference=v3.4.1

--- a/h3version.properties
+++ b/h3version.properties
@@ -1,1 +1,1 @@
-h3.git.reference=v3.4.1
+h3.git.reference=v3.4.2

--- a/src/main/c/h3-java/CMakeLists.txt
+++ b/src/main/c/h3-java/CMakeLists.txt
@@ -31,7 +31,7 @@ set(H3_SOVERSION 1)
 
 project(h3-java LANGUAGES C)
 
-include_directories(${H3_SRC_ROOT}/src/h3lib/include)
+include_directories(${H3_BUILD_ROOT}/src/h3lib/include)
 
 if(USE_NATIVE_JNI)
     find_package(JNI REQUIRED)

--- a/src/main/c/h3-java/build-h3-docker.sh
+++ b/src/main/c/h3-java/build-h3-docker.sh
@@ -42,7 +42,6 @@ H3_BUILD_ROOT="$(pwd)"
 popd
 
 cmake -DBUILD_SHARED_LIBS=ON \
-    -DH3_SRC_ROOT=/work/target/h3 \
     "-DH3_BUILD_ROOT=$H3_BUILD_ROOT" \
     -DCMAKE_BUILD_TYPE=Release \
     /work/src/main/c/h3-java

--- a/src/main/c/h3-java/build-h3-windows.ps1
+++ b/src/main/c/h3-java/build-h3-windows.ps1
@@ -80,7 +80,6 @@ ForEach ($Configuration in
     cmake -G $Configuration.Item2 `
         -DUSE_NATIVE_JNI=ON `
         -DBUILD_SHARED_LIBS=ON `
-        "-DH3_SRC_ROOT=$h3SrcRoot" `
         "-DH3_BUILD_ROOT=$h3BuildRoot" `
         "-DH3_CORE_LIBRARY_PATH=bin/Release/h3" `
         -DCMAKE_BUILD_TYPE=Release `

--- a/src/main/c/h3-java/build-h3.sh
+++ b/src/main/c/h3-java/build-h3.sh
@@ -50,8 +50,6 @@ git fetch origin --tags
 echo Using revision "$GIT_REVISION"
 git checkout "$GIT_REVISION"
 
-H3_SRC_ROOT="$(pwd)"
-
 popd # h3
 
 #
@@ -76,7 +74,6 @@ popd # build
 
 cmake -DUSE_NATIVE_JNI=ON \
     -DBUILD_SHARED_LIBS=ON \
-    "-DH3_SRC_ROOT=$H3_SRC_ROOT" \
     "-DH3_BUILD_ROOT=$H3_BUILD_ROOT" \
     -DCMAKE_BUILD_TYPE=Release \
     ../../src/main/c/h3-java

--- a/src/main/c/h3-java/src/jniapi.c
+++ b/src/main/c/h3-java/src/jniapi.c
@@ -449,6 +449,25 @@ JNIEXPORT jint JNICALL Java_com_uber_h3core_NativeMethods_maxPolyfillSize(
 
 /*
  * Class:     com_uber_h3core_NativeMethods
+ * Method:    getRes0Indexes
+ * Signature: ([J)V
+ */
+JNIEXPORT void JNICALL Java_com_uber_h3core_NativeMethods_getRes0Indexes(
+    JNIEnv *env, jobject thiz, jlongArray results) {
+    jlong *resultsElements = (**env).GetLongArrayElements(env, results, 0);
+
+    if (resultsElements != NULL) {
+        getRes0Indexes(resultsElements);
+
+        (**env).ReleaseLongArrayElements(env, results, resultsElements, 0);
+    } else {
+        ThrowOutOfMemoryError(env);
+        return;
+    }
+}
+
+/*
+ * Class:     com_uber_h3core_NativeMethods
  * Method:    polyfill
  * Signature: ([D[I[DI[J)V
  */

--- a/src/main/java/com/uber/h3core/H3Core.java
+++ b/src/main/java/com/uber/h3core/H3Core.java
@@ -43,6 +43,7 @@ public class H3Core {
      * Maximum number of vertices for an H3 index
      */
     private static final int MAX_CELL_BNDRY_VERTS = 10;
+    private static final int NUM_BASE_CELLS = 122;
 
     // Constants for the resolution bits in an H3 index.
     private static final long H3_RES_OFFSET = 52L;
@@ -968,6 +969,22 @@ public class H3Core {
     }
 
     /**
+     * Returns a collection of all base cells (H3 indexes are resolution 0).
+     */
+    public Collection<String> getRes0IndexesAddresses() {
+        return h3ToStringList(getRes0Indexes());
+    }
+
+    /**
+     * Returns a collection of all base cells (H3 indexes are resolution 0).
+     */
+    public Collection<Long> getRes0Indexes() {
+        long[] indexes = new long[NUM_BASE_CELLS];
+        h3Api.getRes0Indexes(indexes);
+        return nonZeroLongArrayToList(indexes);
+    }
+
+    /**
      * Returns <code>true</code> if the two indexes are neighbors.
      */
     public boolean h3IndexesAreNeighbors(long a, long b) {
@@ -1124,8 +1141,8 @@ public class H3Core {
      * Transforms a list of H3 indexes in long form to a list of H3
      * indexes in string form.
      */
-    private List<String> h3ToStringList(List<Long> list) {
-        return list.stream()
+    private List<String> h3ToStringList(Collection<Long> collection) {
+        return collection.stream()
                 .map(this::h3ToString)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/uber/h3core/NativeMethods.java
+++ b/src/main/java/com/uber/h3core/NativeMethods.java
@@ -65,6 +65,7 @@ final class NativeMethods {
     native double edgeLengthKm(int res);
     native double edgeLengthM(int res);
     native long numHexagons(int res);
+    native void getRes0Indexes(long[] indexes);
 
     native boolean h3IndexesAreNeighbors(long a, long b);
     native long getH3UnidirectionalEdge(long a, long b);

--- a/src/test/java/com/uber/h3core/TestBindingCompleteness.java
+++ b/src/test/java/com/uber/h3core/TestBindingCompleteness.java
@@ -51,6 +51,7 @@ public class TestBindingCompleteness {
             exposed.add(m.getName());
         }
 
+        int checkedFunctions = 0;
         try (Scanner in = new Scanner(new File("./target/binding-functions"), "UTF-8")) {
             while (in.hasNext()) {
                 String function = in.next();
@@ -60,7 +61,9 @@ public class TestBindingCompleteness {
                 }
 
                 assertTrue(function + " is exposed in binding", exposed.contains(function));
+                checkedFunctions++;
             }
         }
+        assertTrue("Checked that the API exists", checkedFunctions > 10);
     }
 }

--- a/src/test/java/com/uber/h3core/TestH3Core.java
+++ b/src/test/java/com/uber/h3core/TestH3Core.java
@@ -769,6 +769,19 @@ public class TestH3Core {
         }
     }
 
+    @Test
+    public void testGetRes0Indexes() {
+        Collection<String> indexesAddresses = h3.getRes0IndexesAddresses();
+        Collection<Long> indexes = h3.getRes0Indexes();
+
+        assertEquals(indexes.size(), indexesAddresses.size());
+
+        for (Long index : indexes) {
+            assertEquals(0, h3.h3GetResolution(index));
+            assertTrue(indexesAddresses.contains(h3.h3ToString(index)));
+        }
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testConstantsInvalid() {
         h3.hexArea(-1, AreaUnit.km2);

--- a/src/test/java/com/uber/h3core/TestH3Core.java
+++ b/src/test/java/com/uber/h3core/TestH3Core.java
@@ -777,7 +777,12 @@ public class TestH3Core {
         assertEquals(indexes.size(), indexesAddresses.size());
 
         for (Long index : indexes) {
+            // Check that the index is unique.
+            assertEquals(1, indexes.stream().filter(i -> i.equals(index)).count());
+            // CHeck that the index is valid and res 0.
+            assertTrue(h3.h3IsValid(index));
             assertEquals(0, h3.h3GetResolution(index));
+            // Both signatures return the same thing.
             assertTrue(indexesAddresses.contains(h3.h3ToString(index)));
         }
     }

--- a/src/test/java/com/uber/h3core/TestH3Core.java
+++ b/src/test/java/com/uber/h3core/TestH3Core.java
@@ -774,16 +774,13 @@ public class TestH3Core {
         Collection<String> indexesAddresses = h3.getRes0IndexesAddresses();
         Collection<Long> indexes = h3.getRes0Indexes();
 
-        assertEquals(indexes.size(), indexesAddresses.size());
+        assertEquals("Both signatures return the same results (size)", indexes.size(), indexesAddresses.size());
 
         for (Long index : indexes) {
-            // Check that the index is unique.
-            assertEquals(1, indexes.stream().filter(i -> i.equals(index)).count());
-            // CHeck that the index is valid and res 0.
-            assertTrue(h3.h3IsValid(index));
-            assertEquals(0, h3.h3GetResolution(index));
-            // Both signatures return the same thing.
-            assertTrue(indexesAddresses.contains(h3.h3ToString(index)));
+            assertEquals("Index is unique", 1, indexes.stream().filter(i -> i.equals(index)).count());
+            assertTrue("Index is valid", h3.h3IsValid(index));
+            assertEquals("Index is res 0", 0, h3.h3GetResolution(index));
+            assertTrue("Both signatures return the same results", indexesAddresses.contains(h3.h3ToString(index)));
         }
     }
 


### PR DESCRIPTION
Adds getRes0Indexes. The number of base cells was inlined as a constant, similar to how `h3ToParent` was implemented.

I added an assertion that the binding functions test is actually testing that some functions are implemented.