### PR TITLE
Fix site target failing on Javadocs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
       env: NAME="Linux without Docker"
       jdk: oraclejdk9
       install:
-        - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dh3.use.docker=false
+        - mvn install -DskipTests=true -B -V -Dh3.use.docker=false
       script:
         - mvn test -B -Dh3.use.docker=false
     - os: osx

--- a/pom.xml
+++ b/pom.xml
@@ -309,6 +309,11 @@
                     <releaseProfiles>release-profile</releaseProfiles>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.7.1</version>
+            </plugin>
         </plugins>
         <resources>
             <resource>
@@ -329,6 +334,11 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
                 <version>3.0.0</version>
             </plugin>
         </plugins>

--- a/src/test/java/com/uber/h3core/TestH3CoreSystemInstance.java
+++ b/src/test/java/com/uber/h3core/TestH3CoreSystemInstance.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assume.assumeTrue;
 
 /**
- * Test that {@see H3Core.newSystemInstance} can load the H3 library. This test is only
+ * Test that {@link H3Core#newSystemInstance()} can load the H3 library. This test is only
  * run if the system property <code>h3.test.system</code> has the value <code>true</code>.
  * It is expected that when running this test, the JVM has been setup to find the native
  * library, either by installing it in a place it can be found, or setting the


### PR DESCRIPTION
Javadocs failed because of a syntax error.

By default, Travis CI skips building Javadocs. This PR also should enable building Javadocs on the Linux without Docker CI job.