### PR TITLE
Update to uber/h3 v3.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The public API of this library consists of the public functions declared in
 file [H3Core.java](./src/main/java/com/uber/h3core/H3Core.java), and support
 for the Linux x64 and Darwin x64 platforms.
 
+## [3.4.1] - 2019-05-03
+### Changed
+- Updated the core library to v3.4.3. (#44)
+
 ## [3.4.0] - 2019-02-22
 ### Added
 - `getRes0Indexes` function. (#38)

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ Add it to your pom.xml:
 <dependency>
     <groupId>com.uber</groupId>
     <artifactId>h3</artifactId>
-    <version>3.4.0</version>
+    <version>3.4.1</version>
 </dependency>
 ```
 
 Or, using Gradle:
 
 ```gradle
-compile("com.uber:h3:3.4.0")
+compile("com.uber:h3:3.4.1")
 ```
 
 Encode a location into a hexagon address:

--- a/h3version.properties
+++ b/h3version.properties
@@ -1,1 +1,1 @@
-h3.git.reference=v3.4.2
+h3.git.reference=v3.4.3

--- a/src/test/java/com/uber/h3core/TestH3Core.java
+++ b/src/test/java/com/uber/h3core/TestH3Core.java
@@ -861,6 +861,11 @@ public class TestH3Core {
         assertEquals(0, h3.uncompactAddress(ImmutableList.of("0"), 3).size());
     }
 
+    @Test(expected = RuntimeException.class)
+    public void testUncompactInvalid() {
+        h3.uncompactAddress(ImmutableList.of("85283473fffffff"), 4);
+    }
+
     @Test
     public void testUnidirectionalEdges() {
         String start = "891ea6d6533ffff";

--- a/src/test/java/com/uber/h3core/TestH3Core.java
+++ b/src/test/java/com/uber/h3core/TestH3Core.java
@@ -856,9 +856,9 @@ public class TestH3Core {
                 .forEach(h -> assertEquals(3, h3.h3GetResolution(h)));
     }
 
-    @Test(expected = RuntimeException.class)
-    public void testUncompactInvalid() {
-        h3.uncompactAddress(ImmutableList.of("0"), 3);
+    @Test
+    public void testUncompactZero() {
+        assertEquals(0, h3.uncompactAddress(ImmutableList.of("0"), 3).size());
     }
 
     @Test


### PR DESCRIPTION
This incorporates the change "Fixed constraints of vertex longitudes (uber/h3#213)"