### PR TITLE
Modified the Travis configuration file to enable automated FOSSA scans.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,4 +42,3 @@ before_script:
 
 script:
   - fossa
-  

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,3 +42,4 @@ before_script:
 
 script:
   - fossa
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,9 @@ matrix:
       script:
         - mvn test -B -Dh3.use.docker=false
     - os: osx
+
+before_script:
+  - "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | sudo bash"
+
+script:
+  - fossa


### PR DESCRIPTION
Hello, I'm from FOSSA and I'm working with the Uber OSPO to automate license scanning. In addition to the changes in this PR, we may also need to add an API key as an environmental variable in the build environment.

I noticed that you defined "scripts" inside the build matrix and didn't run any scripts afterward. I added two additional entries to enable FOSSA: a before_scripts entry and a scripts entry. Does that work for your build environment? I'm totally open to suggestions if what I did doesn't make sense.

Thanks!