### PR TITLE
Switch Travis CI test to Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,13 @@
 # limitations under the License.
 
 language: java
+dist: xenial
 
 sudo: required
 
-dist: xenial
+cache:
+  directories:
+    - $HOME/.m2
 
 services:
   - docker
@@ -29,12 +32,10 @@ matrix:
       script:
         - mvn clean test jacoco:report coveralls:report -Dh3.test.system=true -Dh3.additional.argLine="-Djava.library.path=./src/main/resources/linux-x64/"
     - os: linux
-      jdk: openjdk10
-    - os: linux
       jdk: openjdk11
     - os: linux
       env: NAME="Linux without Docker"
-      jdk: oraclejdk9
+      jdk: oraclejdk11
       install:
         - mvn install -DskipTests=true -B -V -Dh3.use.docker=false
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Copyright 2018 Uber Technologies, Inc.
+# Copyright 2018-2019 Uber Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@ language: java
 
 sudo: required
 
+dist: xenial
+
 services:
   - docker
 
@@ -23,11 +25,13 @@ matrix:
   include:
     - os: linux
       env: NAME="Coverage report"
-      jdk: oraclejdk8
+      jdk: openjdk8
       script:
         - mvn clean test jacoco:report coveralls:report -Dh3.test.system=true -Dh3.additional.argLine="-Djava.library.path=./src/main/resources/linux-x64/"
     - os: linux
-      jdk: openjdk8
+      jdk: openjdk10
+    - os: linux
+      jdk: openjdk11
     - os: linux
       env: NAME="Linux without Docker"
       jdk: oraclejdk9

--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <org.openjdk.jmh.version>1.19</org.openjdk.jmh.version>
+        <maven.javadoc.plugin.version>3.1.1</maven.javadoc.plugin.version>
 
         <h3.git.remote>https://github.com/uber/h3.git</h3.git.remote>
         <h3.use.docker>true</h3.use.docker>
@@ -272,7 +273,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>${maven.javadoc.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -329,7 +330,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>${maven.javadoc.plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -282,6 +282,9 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <source>8</source>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -331,6 +334,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${maven.javadoc.plugin.version}</version>
+                <configuration>
+                    <source>8</source>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
The test was automatically moved to Xenial from Trusty because we didn't specify a `dist`. 

There were a few changes to make this upgrade:
* Xenial has different JDKs available
* Because of the JDK upgrade, Javadoc plugin changes were needed to fix the build
* Enabled caching the Maven directory to speed up future builds (although most of the time is taken by Docker)