### PR TITLE
Update to uber/h3 v3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ file [H3Core.java](./src/main/java/com/uber/h3core/H3Core.java), and support
 for the Linux x64 and Darwin x64 platforms.
 
 ## [3.6.0] - 2019-08-13
+### Added
+- `getPentagonIndexes` and `h3ToCenterChild` functions. (#49)
 ### Changed
 - Updated the core library to v3.6.0. (#49)
+- Native implementations of `getRes0Indexes` and `getPentagonIndexes` changed to throw `OutOfMemoryError` if output array sizes are too small. (#49)
 
 ## [3.5.0] - 2019-07-22
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ for the Linux x64 and Darwin x64 platforms.
 - `getPentagonIndexes` and `h3ToCenterChild` functions. (#49)
 ### Changed
 - Updated the core library to v3.6.0. (#49)
-- Native implementations of `getRes0Indexes` and `getPentagonIndexes` changed to throw `OutOfMemoryError` if output array sizes are too small. (#49)
+- Native implementations of `getRes0Indexes` and `getPentagonIndexes` changed to throw `OutOfMemoryError` if the output array size is too small. (#49)
 
 ## [3.5.0] - 2019-07-22
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ for the Linux x64 and Darwin x64 platforms.
 
 ## [3.6.0] - 2019-08-13
 ### Changed
-- Updated the core library to v3.6.0.
+- Updated the core library to v3.6.0. (#49)
 
 ## [3.5.0] - 2019-07-22
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The public API of this library consists of the public functions declared in
 file [H3Core.java](./src/main/java/com/uber/h3core/H3Core.java), and support
 for the Linux x64 and Darwin x64 platforms.
 
-## [3.6.0] - 2019-08-13
+## [3.6.0] - 2019-08-19
 ### Added
 - `getPentagonIndexes` and `h3ToCenterChild` functions. (#49)
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The public API of this library consists of the public functions declared in
 file [H3Core.java](./src/main/java/com/uber/h3core/H3Core.java), and support
 for the Linux x64 and Darwin x64 platforms.
 
+## [3.6.0] - 2019-08-13
+### Changed
+- Updated the core library to v3.6.0.
+
 ## [3.5.0] - 2019-07-22
 ### Changed
 - Updated the core library to v3.5.0. (#47)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<img align="right" src="https://uber.github.io/res/h3Logo-color.svg" alt="H3 Logo" width="200">
+
 # H3-Java
 
 [![Build Status](https://travis-ci.com/uber/h3-java.svg?branch=master)](https://travis-ci.com/uber/h3-java)
@@ -5,7 +7,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/uber/h3-java/badge.svg?branch=master)](https://coveralls.io/github/uber/h3-java?branch=master)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.uber/h3/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.uber/h3)
-[![H3 Version](https://img.shields.io/badge/h3-v3.5.0-blue.svg)](https://github.com/uber/h3/releases/tag/v3.5.0)
+[![H3 Version](https://img.shields.io/badge/h3-v3.6.0-blue.svg)](https://github.com/uber/h3/releases/tag/v3.6.0)
 
 This library provides Java bindings for the [H3 Core Library](https://github.com/uber/h3). For API reference, please see the [H3 Documentation](https://uber.github.io/h3/).
 
@@ -17,14 +19,14 @@ Add it to your pom.xml:
 <dependency>
     <groupId>com.uber</groupId>
     <artifactId>h3</artifactId>
-    <version>3.5.0</version>
+    <version>3.6.0</version>
 </dependency>
 ```
 
 Or, using Gradle:
 
 ```gradle
-compile("com.uber:h3:3.5.0")
+compile("com.uber:h3:3.6.0")
 ```
 
 Encode a location into a hexagon address:

--- a/h3version.properties
+++ b/h3version.properties
@@ -1,1 +1,1 @@
-h3.git.reference=v3.5.0
+h3.git.reference=v3.6.0

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.3</version>
+                <version>0.8.4</version>
                 <executions>
                     <execution>
                         <id>jacoco-instrument</id>

--- a/src/main/c/h3-java/src/jniapi.c
+++ b/src/main/c/h3-java/src/jniapi.c
@@ -454,10 +454,41 @@ JNIEXPORT jint JNICALL Java_com_uber_h3core_NativeMethods_maxPolyfillSize(
  */
 JNIEXPORT void JNICALL Java_com_uber_h3core_NativeMethods_getRes0Indexes(
     JNIEnv *env, jobject thiz, jlongArray results) {
+    jsize size = (**env).GetArrayLength(env, results);
+    if (size < res0IndexCount()) {
+        ThrowOutOfMemoryError(env);
+        return;
+    }
+
     jlong *resultsElements = (**env).GetLongArrayElements(env, results, 0);
 
     if (resultsElements != NULL) {
         getRes0Indexes(resultsElements);
+
+        (**env).ReleaseLongArrayElements(env, results, resultsElements, 0);
+    } else {
+        ThrowOutOfMemoryError(env);
+        return;
+    }
+}
+
+/*
+ * Class:     com_uber_h3core_NativeMethods
+ * Method:    getPentagonIndexes
+ * Signature: (I[J)V
+ */
+JNIEXPORT void JNICALL Java_com_uber_h3core_NativeMethods_getPentagonIndexes(
+    JNIEnv *env, jobject thiz, jint res, jlongArray results) {
+    jsize size = (**env).GetArrayLength(env, results);
+    if (size < pentagonIndexCount()) {
+        ThrowOutOfMemoryError(env);
+        return;
+    }
+
+    jlong *resultsElements = (**env).GetLongArrayElements(env, results, 0);
+
+    if (resultsElements != NULL) {
+        getPentagonIndexes(res, resultsElements);
 
         (**env).ReleaseLongArrayElements(env, results, resultsElements, 0);
     } else {
@@ -637,6 +668,16 @@ JNIEXPORT void JNICALL Java_com_uber_h3core_NativeMethods_h3ToChildren(
     } else {
         ThrowOutOfMemoryError(env);
     }
+}
+
+/*
+ * Class:     com_uber_h3core_NativeMethods
+ * Method:    h3ToCenterChild
+ * Signature: (JI)J
+ */
+JNIEXPORT jlong JNICALL Java_com_uber_h3core_NativeMethods_h3ToCenterChild(
+    JNIEnv *env, jobject thiz, jlong h3, jint childRes) {
+    return h3ToCenterChild(h3, childRes);
 }
 
 /*

--- a/src/main/c/h3-java/src/jniapi.c
+++ b/src/main/c/h3-java/src/jniapi.c
@@ -468,7 +468,6 @@ JNIEXPORT void JNICALL Java_com_uber_h3core_NativeMethods_getRes0Indexes(
         (**env).ReleaseLongArrayElements(env, results, resultsElements, 0);
     } else {
         ThrowOutOfMemoryError(env);
-        return;
     }
 }
 
@@ -493,7 +492,6 @@ JNIEXPORT void JNICALL Java_com_uber_h3core_NativeMethods_getPentagonIndexes(
         (**env).ReleaseLongArrayElements(env, results, resultsElements, 0);
     } else {
         ThrowOutOfMemoryError(env);
-        return;
     }
 }
 

--- a/src/main/java/com/uber/h3core/H3Core.java
+++ b/src/main/java/com/uber/h3core/H3Core.java
@@ -863,7 +863,7 @@ public class H3Core {
         if (result == INVALID_INDEX) {
             // This occurs when the child resolution is out of range for this index.
             throw new IllegalArgumentException(
-                    String.format("resolution %d is out of range (must be %d <= childRes <= %d)",
+                    String.format("childRes %d must be between %d and 15, inclusive",
                             childRes, h3GetResolution(h3))
             );
         }

--- a/src/main/java/com/uber/h3core/NativeMethods.java
+++ b/src/main/java/com/uber/h3core/NativeMethods.java
@@ -31,6 +31,7 @@ final class NativeMethods {
 
     native int maxH3ToChildrenSize(long h3, int childRes);
     native void h3ToChildren(long h3, int childRes, long[] results);
+    native long h3ToCenterChild(long h3, int childRes);
 
     native boolean h3IsValid(long h3);
     native int h3GetBaseCell(long h3);
@@ -66,6 +67,7 @@ final class NativeMethods {
     native double edgeLengthM(int res);
     native long numHexagons(int res);
     native void getRes0Indexes(long[] indexes);
+    native void getPentagonIndexes(int res, long[] h3);
 
     native boolean h3IndexesAreNeighbors(long a, long b);
     native long getH3UnidirectionalEdge(long a, long b);

--- a/src/test/java/com/uber/h3core/TestH3Core.java
+++ b/src/test/java/com/uber/h3core/TestH3Core.java
@@ -98,6 +98,35 @@ public class TestH3Core extends BaseTestH3Core {
         }
     }
 
+    @Test
+    public void testGetPentagonIndexes() {
+        for (int res = 0; res < 16; res++) {
+            Collection<String> indexesAddresses = h3.getPentagonIndexesAddresses(res);
+            Collection<Long> indexes = h3.getPentagonIndexes(res);
+
+            assertEquals("Both signatures return the same results (size)", indexes.size(), indexesAddresses.size());
+            assertEquals("There are 12 pentagons per resolution", 12, indexes.size());
+
+            for (Long index : indexes) {
+                assertEquals("Index is unique", 1, indexes.stream().filter(i -> i.equals(index)).count());
+                assertTrue("Index is valid", h3.h3IsValid(index));
+                assertEquals(String.format("Index is res %d", res), res, h3.h3GetResolution(index));
+                assertTrue("Both signatures return the same results", indexesAddresses.contains(h3.h3ToString(index)));
+                assertTrue("Index is a pentagon", h3.h3IsPentagon(index));
+            }
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetPentagonIndexesNegativeRes() {
+        h3.getPentagonIndexesAddresses(-1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetPentagonIndexesOutOfRangeRes() {
+        h3.getPentagonIndexesAddresses(20);
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testConstantsInvalid() {
         h3.hexArea(-1, AreaUnit.km2);

--- a/src/test/java/com/uber/h3core/TestHierarchy.java
+++ b/src/test/java/com/uber/h3core/TestHierarchy.java
@@ -146,4 +146,31 @@ public class TestHierarchy extends BaseTestH3Core {
     public void testUncompactInvalid() {
         h3.uncompactAddress(ImmutableList.of("85283473fffffff"), 4);
     }
+
+    @Test
+    public void testH3ToCenterChild() {
+        assertEquals("8928308280fffff", h3.h3ToCenterChild("8928308280fffff", 9));
+        assertEquals(0x8928308280fffffL, h3.h3ToCenterChild(0x8928308280fffffL, 9));
+
+        assertEquals("8a28308280c7fff", h3.h3ToCenterChild("8928308280fffff", 10));
+        assertEquals(0x8a28308280c7fffL, h3.h3ToCenterChild(0x8928308280fffffL, 10));
+
+        assertEquals("8b28308280c0fff", h3.h3ToCenterChild("8928308280fffff", 11));
+        assertEquals(0x8b28308280c0fffL, h3.h3ToCenterChild(0x8928308280fffffL, 11));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testH3ToCenterChildParent() {
+        h3.h3ToCenterChild("8928308280fffff", 8);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testH3ToCenterChildNegative() {
+        h3.h3ToCenterChild("8928308280fffff", -1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testH3ToCenterChildOutOfRange() {
+        h3.h3ToCenterChild("8928308280fffff", 16);
+    }
 }

--- a/src/test/java/com/uber/h3core/TestHierarchy.java
+++ b/src/test/java/com/uber/h3core/TestHierarchy.java
@@ -149,14 +149,14 @@ public class TestHierarchy extends BaseTestH3Core {
 
     @Test
     public void testH3ToCenterChild() {
-        assertEquals("8928308280fffff", h3.h3ToCenterChild("8928308280fffff", 9));
-        assertEquals(0x8928308280fffffL, h3.h3ToCenterChild(0x8928308280fffffL, 9));
+        assertEquals("Same resolution as parent results in same index", "8928308280fffff", h3.h3ToCenterChild("8928308280fffff", 9));
+        assertEquals("Same resolution as parent results in same index", 0x8928308280fffffL, h3.h3ToCenterChild(0x8928308280fffffL, 9));
 
-        assertEquals("8a28308280c7fff", h3.h3ToCenterChild("8928308280fffff", 10));
-        assertEquals(0x8a28308280c7fffL, h3.h3ToCenterChild(0x8928308280fffffL, 10));
+        assertEquals("Direct center child is correct", "8a28308280c7fff", h3.h3ToCenterChild("8928308280fffff", 10));
+        assertEquals("Direct center child is correct", 0x8a28308280c7fffL, h3.h3ToCenterChild(0x8928308280fffffL, 10));
 
-        assertEquals("8b28308280c0fff", h3.h3ToCenterChild("8928308280fffff", 11));
-        assertEquals(0x8b28308280c0fffL, h3.h3ToCenterChild(0x8928308280fffffL, 11));
+        assertEquals("Center child skipping a resolution is correct", "8b28308280c0fff", h3.h3ToCenterChild("8928308280fffff", 11));
+        assertEquals("Center child skipping a resolution is correct", 0x8b28308280c0fffL, h3.h3ToCenterChild(0x8928308280fffffL, 11));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/com/uber/h3core/TestNativeMethods.java
+++ b/src/test/java/com/uber/h3core/TestNativeMethods.java
@@ -16,6 +16,7 @@
 package com.uber.h3core;
 
 import com.uber.h3core.util.GeoCoord;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -30,13 +31,18 @@ import static org.junit.Assert.assertTrue;
  * Tests for JNI code without going through {@link H3Core}.
  */
 public class TestNativeMethods {
+    protected static NativeMethods nativeMethods;
+
+    @BeforeClass
+    public static void setup() throws IOException {
+        nativeMethods = H3CoreLoader.loadNatives();
+    }
+
     /**
      * Test that h3SetToLinkedGeo properly propagates an exception
      */
     @Test
-    public void testH3SetToLinkedGeoException() throws IOException {
-        NativeMethods nativeMethods = H3CoreLoader.loadNatives();
-
+    public void testH3SetToLinkedGeoException() {
         final AtomicInteger counter = new AtomicInteger(0);
 
         try {
@@ -51,5 +57,15 @@ public class TestNativeMethods {
             assertEquals("crashed#0", ex.getMessage());
         }
         assertEquals(1, counter.get());
+    }
+
+    @Test(expected = OutOfMemoryError.class)
+    public void getRes0IndexesTooSmall() {
+        nativeMethods.getRes0Indexes(new long[1]);
+    }
+
+    @Test(expected = OutOfMemoryError.class)
+    public void getPentagonIndexes() {
+        nativeMethods.getPentagonIndexes(1, new long[1]);
     }
 }


### PR DESCRIPTION
Bumps the core library to v3.6.0, and adds `getPentagonIndexes` and `h3ToCenterChild`.

Adds the logo to the readme file.

Also includes a change to the C code to throw OutOfMemoryError if requirements about the size of the output arrays are violated for `getRes0Indexes` and `getPentagonIndexes`.