### PR TITLE
Update core library to v3.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The public API of this library consists of the public functions declared in
 file [H3Core.java](./src/main/java/com/uber/h3core/H3Core.java), and support
 for the Linux x64 and Darwin x64 platforms.
 
+## [Unreleased]
+### Changed
+- Updated the core library to v3.6.1. (#53)
+
 ## [3.6.0] - 2019-08-19
 ### Added
 - `getPentagonIndexes` and `h3ToCenterChild` functions. (#49)

--- a/h3version.properties
+++ b/h3version.properties
@@ -1,1 +1,1 @@
-h3.git.reference=v3.6.0
+h3.git.reference=v3.6.1


### PR DESCRIPTION
Not sure if you all are waiting on anything else for 3.6.1, but the updated polyfill algorithm seems to be working well here:

`PolyfillBenchmark` using core v3.6.0:
```
Benchmark                                         Mode  Cnt    Score   Error  Units
PolyfillBenchmark.benchmarkPolyfill              thrpt   20  645.709 ± 5.664  ops/s
PolyfillBenchmark.benchmarkPolyfillWithHole      thrpt   20  645.329 ± 2.836  ops/s
PolyfillBenchmark.benchmarkPolyfillWithTwoHoles  thrpt   20  640.004 ± 2.311  ops/s
```

`PolyfillBenchmark` using core v.3.6.1:
```
Benchmark                                         Mode  Cnt    Score   Error  Units
PolyfillBenchmark.benchmarkPolyfill              thrpt   20  735.690 ± 1.908  ops/s
PolyfillBenchmark.benchmarkPolyfillWithHole      thrpt   20  684.496 ± 2.169  ops/s
PolyfillBenchmark.benchmarkPolyfillWithTwoHoles  thrpt   20  641.440 ± 1.687  ops/s
```