### PR TITLE
add support for building on FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ H3-Java provides bindings to the H3 library, which is written in C. The built ar
 | Linux            | x64, x86, ARM64, ARMv5, ARMv7, MIPS, MIPSEL, PPC64LE, s390x
 | Windows          | x64, x86
 | Darwin (Mac OSX) | x64
+| FreeBSD          | x64
 | Android          | ARM, ARM64
 
 You may be able to build H3-Java locally if you need to use an operating system or architecture not listed above.
@@ -75,6 +76,14 @@ mvn package
 ```
 
 Additional information on how the build process works is available in the [build process documentaiton](docs/library-build.md).
+
+## Building on FreeBSD
+
+```sh
+# To install build dependencies
+sudo pkg install openjdk11 maven33 cmake
+# Ensure /usr/local/openjdk11/bin is on your path
+```
 
 ## Javadocs
 

--- a/src/main/c/h3-java/build-h3.sh
+++ b/src/main/c/h3-java/build-h3.sh
@@ -94,6 +94,7 @@ case "$(uname -sm)" in
     "Linux i786")    LIBRARY_DIR=linux-x86 ;;
     "Linux i886")    LIBRARY_DIR=linux-x86 ;;
     "Darwin x86_64") LIBRARY_DIR=darwin-x64 ;;
+    "FreeBSD amd64") LIBRARY_DIR=freebsd-x64 ;;
     # TODO: Detect others
     *)               LIBRARY_DIR="" ;;
 esac

--- a/src/main/java/com/uber/h3core/H3CoreLoader.java
+++ b/src/main/java/com/uber/h3core/H3CoreLoader.java
@@ -146,6 +146,7 @@ public final class H3CoreLoader {
     public enum OperatingSystem {
         ANDROID(".so"),
         DARWIN(".dylib"),
+        FREEBSD(".so"),
         WINDOWS(".dll"),
         LINUX(".so");
 
@@ -188,6 +189,8 @@ public final class H3CoreLoader {
             return OperatingSystem.DARWIN;
         } else if (javaOs.contains("win")) {
             return OperatingSystem.WINDOWS;
+        } else if (javaOs.contains("freebsd")) {
+            return OperatingSystem.FREEBSD;
         } else {
             // Only other supported platform
             return OperatingSystem.LINUX;


### PR DESCRIPTION
Two things also need to be done (by others) before merging:

1. Update h3-java to the v3.7.0 bindings ( @isaacbrodsky ? )
2. Need a new tag of h3 post v3.7.0 that includes the merged PRs in h3 issue #386 (for `h3version.properties`)