### PR TITLE
Test for Turkish locale

### DIFF
--- a/src/main/java/com/uber/h3core/H3CoreLoader.java
+++ b/src/main/java/com/uber/h3core/H3CoreLoader.java
@@ -20,6 +20,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Locale;
 
 /**
  * Extracts the native H3 core library to the local filesystem and loads it.
@@ -28,6 +29,12 @@ public final class H3CoreLoader {
     private H3CoreLoader() {
         // Prevent instantiation
     }
+
+    /**
+     * Locale used when handling system strings that need to be mapped to resource names.
+     * English is used since that locale was used when building the library.
+     */
+    static final Locale H3_CORE_LOCALE = Locale.ENGLISH;
 
     // Supported H3 architectures
     static final String ARCH_X64 = "x64";
@@ -167,7 +174,7 @@ public final class H3CoreLoader {
          * How this operating system's name is rendered when extracting the native library.
          */
         public String getDirName() {
-            return name().toLowerCase();
+            return name().toLowerCase(H3_CORE_LOCALE);
         }
     }
 
@@ -180,11 +187,11 @@ public final class H3CoreLoader {
     static final OperatingSystem detectOs(String javaVendor, String osName) {
         // Detecting Android using the properties from:
         // https://developer.android.com/reference/java/lang/System.html
-        if (javaVendor.toLowerCase().contains("android")) {
+        if (javaVendor.toLowerCase(H3_CORE_LOCALE).contains("android")) {
             return OperatingSystem.ANDROID;
         }
 
-        String javaOs = osName.toLowerCase();
+        String javaOs = osName.toLowerCase(H3_CORE_LOCALE);
         if (javaOs.contains("mac")) {
             return OperatingSystem.DARWIN;
         } else if (javaOs.contains("win")) {

--- a/src/test/java/com/uber/h3core/TestH3CoreLoaderLocale.java
+++ b/src/test/java/com/uber/h3core/TestH3CoreLoaderLocale.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017-2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.h3core;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import java.io.File;
+import java.io.IOException;
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * H3CoreLoader is mostly tested by {@link TestH3Core}. This also tests OS detection under different locales.
+ */
+@NotThreadSafe
+public class TestH3CoreLoaderLocale {
+    private static Locale systemLocale;
+
+    @BeforeClass
+    public static void setup() {
+        systemLocale = Locale.getDefault();
+        // Turkish is used as the test locale as the Turkish lower case I
+        // is dotless and this frequently triggers locale-dependent bugs.
+        Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        Locale.setDefault(systemLocale);
+    }
+
+    @Test
+    public void testDetectOs() {
+        assertEquals(H3CoreLoader.OperatingSystem.ANDROID,
+                H3CoreLoader.detectOs("ANDROID", "anything"));
+        assertEquals(H3CoreLoader.OperatingSystem.WINDOWS,
+                H3CoreLoader.detectOs("vendor", "WINDOWS"));
+        assertEquals(H3CoreLoader.OperatingSystem.LINUX,
+                H3CoreLoader.detectOs("vendor", "LINUX"));
+
+        assertEquals(H3CoreLoader.OperatingSystem.LINUX,
+                H3CoreLoader.detectOs("vendor", "anything else"));
+    }
+
+    @Test
+    public void testDetectArch() {
+        assertEquals("I386", H3CoreLoader.detectArch("I386"));
+    }
+
+    @Test
+    public void testOsDir() {
+        assertEquals("Turkish lower case I (Darwin)", "darwin", H3CoreLoader.OperatingSystem.DARWIN.getDirName());
+        assertEquals("Turkish lower case I (Linux)", "linux", H3CoreLoader.OperatingSystem.LINUX.getDirName());
+        assertEquals("Turkish lower case I (Windows)", "windows", H3CoreLoader.OperatingSystem.WINDOWS.getDirName());
+        assertEquals("Turkish lower case I (Android)", "android", H3CoreLoader.OperatingSystem.ANDROID.getDirName());
+    }
+}


### PR DESCRIPTION
Fixes #79.

Turkish has a dotless lower case `I` which makes it very convenient for testing locale-dependent bugs. I tried to address every case of `toLowerCase` in the library.

Another approach here would be to allow the user to specify which native library file should be used directly, without going through the detection process.

A couple build-time things that would help here are static analysis for locale-dependency, and upgrading to Junit5 (for newer/nicer test harnesses)