### PR TITLE
Support Apple M1 build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ file [H3Core.java](./src/main/java/com/uber/h3core/H3Core.java), and support
 for the Linux x64 and Darwin x64 platforms.
 
 ## [Unreleased]
+## Fixed
+- Fixes local build script to support Apple M1
 
 ## [3.7.1] - 2021-08-18
 ## Fixed

--- a/src/main/c/h3-java/build-h3.sh
+++ b/src/main/c/h3-java/build-h3.sh
@@ -98,6 +98,7 @@ case "$(uname -sm)" in
     "Linux i786")    LIBRARY_DIR=linux-x86 ;;
     "Linux i886")    LIBRARY_DIR=linux-x86 ;;
     "Darwin x86_64") LIBRARY_DIR=darwin-x64 ;;
+    "Darwin arm64")  LIBRARY_DIR=darwin-arm64 ;;
     "FreeBSD amd64") LIBRARY_DIR=freebsd-x64 ;;
     # TODO: Detect others
     *)               LIBRARY_DIR="" ;;


### PR DESCRIPTION
From this issue: https://github.com/uber/h3-java/issues/73

I found that build script on Apple M1 was broken due to `libh3-java.dylib` was build and put into invalid path. By adding a case for `Darwin arm64` in build script which make final output of dylib location to be correct so the build will be pass.