### PR TITLE
Pin specific dockcross version

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ H3-Java provides bindings to the H3 library, which is written in C. The built ar
 
 | Operating System | Architectures
 | ---------------- | -------------
-| Linux            | x64, x86, ARM64, ARMv5, ARMv7, MIPS, MIPSEL, PPC64LE, s390x
+| Linux            | x64, x86, ARM64, ARMv5, ARMv7, MIPS, PPC64LE, s390x
 | Windows          | x64, x86
 | Darwin (Mac OSX) | x64, ARM64
 | FreeBSD          | x64

--- a/src/main/c/h3-java/build-h3.sh
+++ b/src/main/c/h3-java/build-h3.sh
@@ -156,6 +156,8 @@ if ! command -v docker; then
     exit 0
 fi
 
+dockcross_tag="20211126-f096312"
+
 # linux-armv6 excluded because of build failure
 for image in android-arm android-arm64 linux-arm64 linux-armv5 linux-armv7 linux-mipsel linux-mips linux-s390x \
     linux-ppc64le linux-x64 linux-x86 windows-x64 windows-x86; do
@@ -163,8 +165,8 @@ for image in android-arm android-arm64 linux-arm64 linux-armv5 linux-armv7 linux
     # Setup for using dockcross
     BUILD_ROOT=target/h3-java-build-$image
     mkdir -p $BUILD_ROOT
-    docker pull dockcross/$image
-    docker run --rm dockcross/$image > $BUILD_ROOT/dockcross
+    docker pull dockcross/$image:$dockcross_tag
+    docker run --rm dockcross/$image:$dockcross_tag > $BUILD_ROOT/dockcross
     chmod +x $BUILD_ROOT/dockcross
 
     # Perform the actual build inside Docker

--- a/src/main/c/h3-java/build-h3.sh
+++ b/src/main/c/h3-java/build-h3.sh
@@ -159,8 +159,8 @@ fi
 dockcross_tag="20211126-f096312"
 
 # linux-armv6 excluded because of build failure
-for image in android-arm android-arm64 linux-arm64 linux-armv5 linux-armv7 linux-mipsel linux-mips linux-s390x \
-    linux-ppc64le linux-x64 linux-x86 windows-x64 windows-x86; do
+for image in android-arm android-arm64 linux-arm64 linux-armv5 linux-armv7 linux-mips linux-s390x \
+    linux-ppc64le linux-x64 linux-x86 windows-static-x64 windows-static-x86; do
 
     # Setup for using dockcross
     BUILD_ROOT=target/h3-java-build-$image
@@ -175,6 +175,12 @@ for image in android-arm android-arm64 linux-arm64 linux-armv5 linux-armv7 linux
     # Copy the built artifact into the source tree so it can be included in the
     # built JAR.
     OUTPUT_ROOT=src/main/resources/$image
+    if [ "$image" -eq "windows-static-x64" ]; then
+        OUTPUT_ROOT=src/main/resources/windows-x64
+    fi
+    if [ "$image" -eq "windows-static-x86" ]; then
+        OUTPUT_ROOT=src/main/resources/windows-x86
+    fi
     mkdir -p $OUTPUT_ROOT
     if [ -e $BUILD_ROOT/lib/libh3-java.so ]; then cp $BUILD_ROOT/lib/libh3-java.so $OUTPUT_ROOT ; fi
     if [ -e $BUILD_ROOT/lib/libh3-java.dylib ]; then cp $BUILD_ROOT/lib/libh3-java.dylib $OUTPUT_ROOT ; fi


### PR DESCRIPTION
Replaces #88. For #85, know exactly which version of dockcross is being used.