### PR TITLE
Publish Javadocs to Github Pages

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
         run: mvn com.spotify.fmt:fmt-maven-plugin:check
 
       - name: Tests
-        run: mvn "-Dh3.remove.images=true" -B -V clean test
+        run: mvn "-Dh3.remove.images=true" -B -V clean test site
 
   tests-no-docker:
     name: Java (No Docker) ${{ matrix.java-version }} ${{ matrix.os }}
@@ -72,7 +72,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Tests
-        run: mvn -B -V clean test
+        run: mvn -B -V clean test site
 
   tests-coverage:
     name: Java (Coverage) ${{ matrix.java-version }} ${{ matrix.os }}

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,0 +1,39 @@
+
+on:
+  push:
+    branches:
+      - master
+
+# This job installs dependencies, builds the website, and pushes it to `gh-pages`
+jobs:
+  deploy-website:
+    name: Deploy website
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2.4.0
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: "adopt"
+          java-version: "15"
+
+      - uses: actions/cache@v2
+        id: maven-cache
+        with:
+          path: ~/.m2/
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Javadocs Build
+        working-directory: website
+        run: |
+          mvn -B -C clean site -Dh3.use.docker=false
+
+      # Deploy the book's HTML to gh-pages branch
+      - name: GitHub Pages action
+        uses: peaceiris/actions-gh-pages@v3.8.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: target/site/apidocs/

--- a/pom.xml
+++ b/pom.xml
@@ -363,9 +363,9 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.0</version>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>4.5.3.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/test/java/com/uber/h3core/TestH3CoreLoader.java
+++ b/src/test/java/com/uber/h3core/TestH3CoreLoader.java
@@ -21,7 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import org.junit.Test;
 
-/** H3CoreLoader is mostly tested by {@link TestH3Core}. This also tests OS detection. */
+/** H3CoreLoader is mostly tested by {@link TestH3CoreFactory}. This also tests OS detection. */
 public class TestH3CoreLoader {
   @Test
   public void testDetectOs() {

--- a/src/test/java/com/uber/h3core/TestH3CoreLoaderLocale.java
+++ b/src/test/java/com/uber/h3core/TestH3CoreLoaderLocale.java
@@ -24,8 +24,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * H3CoreLoader is mostly tested by {@link TestH3Core}. This also tests OS detection under different
- * locales.
+ * H3CoreLoader is mostly tested by {@link TestH3CoreFactory}. This also tests OS detection under
+ * different locales.
  */
 @NotThreadSafe
 public class TestH3CoreLoaderLocale {

--- a/src/test/java/com/uber/h3core/v3/BaseTestH3CoreV3.java
+++ b/src/test/java/com/uber/h3core/v3/BaseTestH3CoreV3.java
@@ -19,7 +19,7 @@ import com.uber.h3core.H3CoreV3;
 import java.io.IOException;
 import org.junit.BeforeClass;
 
-/** Base class for tests of the class {@link H3Core} */
+/** Base class for tests of the class {@link H3CoreV3} */
 public abstract class BaseTestH3CoreV3 {
   public static final double EPSILON = 1e-6;
 

--- a/src/test/java/com/uber/h3core/v3/TestMiscellaneous.java
+++ b/src/test/java/com/uber/h3core/v3/TestMiscellaneous.java
@@ -25,7 +25,7 @@ import com.uber.h3core.util.LatLng;
 import java.util.Collection;
 import org.junit.Test;
 
-/** Tests for {@link H3Core} instantiation and miscellaneous functions. */
+/** Tests for {@link com.uber.h3core.H3CoreV3} instantiation and miscellaneous functions. */
 public class TestMiscellaneous extends BaseTestH3CoreV3 {
   @Test
   public void testConstants() {


### PR DESCRIPTION
Automatically build and publish the Javadocs for h3-java. The main API documentation is still at h3geo.org/ but Java specifics can be found here.

In the future we might want to publish `target/site` including dependency information, but I'll leave that for later after looking at how to configure various parts of it.