### PR TITLE
pin dockcross version farther back

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
         run: mvn "-Dh3.remove.images=true" -B -V clean test site
 
   tests-new-dockcross:
-    name: Java ${{ matrix.java-version }} ${{ matrix.os }}
+    name: Dockcross ${{ matrix.dockcross-tag }} Java ${{ matrix.java-version }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
         run: mvn com.spotify.fmt:fmt-maven-plugin:check
 
       - name: Tests
-        run: mvn "-Dh3.remove.images=true" -B -V clean test site
+        run: mvn "-Dh3.system.prune=true" -B -V clean test site
 
   tests-new-dockcross:
     name: Dockcross ${{ matrix.dockcross-tag }} Java ${{ matrix.java-version }} ${{ matrix.os }}
@@ -50,7 +50,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         java-distribution: [adopt]
-        java-version: [15]
+        java-version: [17]
         dockcross-tag: ["20220528-e4627de"]
 
     steps:
@@ -72,7 +72,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Tests
-        run: mvn "-Dh3.remove.images=true" "-Dh3.dockcross.tag=${{ matrix.dockcross-tag }}" -B -V clean test
+        run: mvn "-Dh3.system.prune=true" "-Dh3.dockcross.tag=${{ matrix.dockcross-tag }}" -B -V clean test
 
   tests-no-docker:
     name: Java (No Docker) ${{ matrix.java-version }} ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         java-distribution: [adopt]
-        java-version: [8, 11, 15]
+        java-version: [8, 11, 15, 17]
 
     steps:
       - uses: actions/checkout@v2.1.1
@@ -72,7 +72,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Tests
-        run: mvn "-Dh3.remove.images=true" "-Dh3.dockcross.tag=${{ matrix.dockcross-tag }}" -B -V clean test site
+        run: mvn "-Dh3.remove.images=true" "-Dh3.dockcross.tag=${{ matrix.dockcross-tag }}" -B -V clean test
 
   tests-no-docker:
     name: Java (No Docker) ${{ matrix.java-version }} ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,38 @@ jobs:
       - name: Tests
         run: mvn "-Dh3.remove.images=true" -B -V clean test site
 
+  tests-new-dockcross:
+    name: Java ${{ matrix.java-version }} ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        java-distribution: [adopt]
+        java-version: [15]
+        dockcross-tag: ["20220528-e4627de"]
+
+    steps:
+      - uses: actions/checkout@v2.1.1
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: "${{ matrix.java-distribution }}"
+          java-version: "${{ matrix.java-version }}"
+
+      - uses: actions/cache@v2
+        id: maven-cache
+        with:
+          path: ~/.m2/
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Tests
+        run: mvn "-Dh3.remove.images=true" "-Dh3.dockcross.tag=${{ matrix.dockcross-tag }}" -B -V clean test site
+
   tests-no-docker:
     name: Java (No Docker) ${{ matrix.java-version }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -51,7 +83,7 @@ jobs:
         # TODO: Docker on macos-latest running is not working
         os: [macos-latest, windows-latest]
         java-distribution: [adopt]
-        java-version: [8, 11, 15]
+        java-version: [8, 11, 15, 17]
 
     steps:
       - uses: actions/checkout@v2.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The public API of this library consists of the public functions declared in
 file [H3Core.java](./src/main/java/com/uber/h3core/H3Core.java), and support
 for the Linux x64 and Darwin x64 platforms.
 
+## [4.0.0-rc2] - Unreleased
+### Changed
+- Required version of glibc on Linux is 2.26. (#98)
+
+### Removed
+- Removed support for Linux MIPS (#98)
+
 ## [4.0.0-rc1] - 2022-03-29
 ### Breaking Changes
 - Changed the API of `H3Core` to align it with the core library. (#91)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ H3-Java provides bindings to the H3 library, which is written in C. The built ar
 
 | Operating System | Architectures
 | ---------------- | -------------
-| Linux            | x64, x86, ARM64, ARMv5, ARMv7, MIPS, PPC64LE, s390x
+| Linux            | x64, x86, ARM64, ARMv5, ARMv7, PPC64LE, s390x
 | Windows          | x64, x86
 | Darwin (Mac OSX) | x64, ARM64
 | FreeBSD          | x64

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
         <h3.git.remote>https://github.com/uber/h3.git</h3.git.remote>
         <h3.use.docker>true</h3.use.docker>
         <h3.remove.images>false</h3.remove.images>
+        <h3.dockcross.tag>20210624-de7b1b0</h3.dockcross.tag>
         <!-- Used for passing additional arguments to surefire when using JaCoCo -->
         <h3.additional.argLine />
 
@@ -266,6 +267,7 @@
                                 <argument>${h3.git.reference}</argument>
                                 <argument>${h3.use.docker}</argument>
                                 <argument>${h3.remove.images}</argument>
+                                <argument>${h3.dockcross.tag}</argument>
                             </arguments>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 
         <h3.git.remote>https://github.com/uber/h3.git</h3.git.remote>
         <h3.use.docker>true</h3.use.docker>
-        <h3.remove.images>false</h3.remove.images>
+        <h3.system.prune>false</h3.system.prune>
         <h3.dockcross.tag>20210624-de7b1b0</h3.dockcross.tag>
         <!-- Used for passing additional arguments to surefire when using JaCoCo -->
         <h3.additional.argLine />
@@ -266,7 +266,7 @@
                                 <argument>${h3.git.remote}</argument>
                                 <argument>${h3.git.reference}</argument>
                                 <argument>${h3.use.docker}</argument>
-                                <argument>${h3.remove.images}</argument>
+                                <argument>${h3.system.prune}</argument>
                                 <argument>${h3.dockcross.tag}</argument>
                             </arguments>
                         </configuration>

--- a/src/main/c/h3-java/build-h3-docker.sh
+++ b/src/main/c/h3-java/build-h3-docker.sh
@@ -15,8 +15,10 @@
 # limitations under the License.
 #
 
-# Arguments: [build-root]
-# build-root - Location to build the library.
+# Arguments: [build-root] [upgrade-cmake]
+# build-root    - Location to build the library.
+# upgrade-cmake - Whether to download and install a new version of CMake
+# cmake-root    - Where to download and install the new version of CMake
 #
 # Builds H3 and H3-Java in the given directory. This is intended to be
 # called from build-h3.sh as part of the cross compilation process.
@@ -24,8 +26,26 @@
 set -ex
 
 BUILD_ROOT=$1
+UPGRADE_CMAKE=$2
+CMAKE_ROOT=$3
 
-cd $BUILD_ROOT
+if $UPGRADE_CMAKE; then
+    pushd "$CMAKE_ROOT"
+    if ! [ -e cmake-3.23.2-linux-x86_64.sh ]; then
+        wget -nv https://github.com/Kitware/CMake/releases/download/v3.23.2/cmake-3.23.2-linux-x86_64.sh
+    fi
+    echo "5cca63af386e5bd0bde67c87ffac915865abd7dcc48073528f58645abda8f695  cmake-3.23.2-linux-x86_64.sh" > cmake-3.23.2-SHA-256.txt
+    sha256sum -c cmake-3.23.2-SHA-256.txt
+    if ! [ -e ./bin/cmake ]; then
+        chmod a+x cmake-3.23.2-linux-x86_64.sh
+        ./cmake-3.23.2-linux-x86_64.sh --skip-license
+    fi
+    export PATH=$(pwd)/bin:$PATH
+    cmake --version
+    popd
+fi
+
+cd "$BUILD_ROOT"
 
 mkdir -p build
 pushd build

--- a/src/main/c/h3-java/build-h3.sh
+++ b/src/main/c/h3-java/build-h3.sh
@@ -193,7 +193,8 @@ for image in android-arm android-arm64 linux-arm64 linux-armv5 linux-armv7 linux
     if [ -e $BUILD_ROOT/lib/libh3-java.dll ]; then cp $BUILD_ROOT/lib/libh3-java.dll $OUTPUT_ROOT ; fi
 
     if $SYSTEM_PRUNE; then
-        docker system prune --force
+        docker system prune --force --all
+        docker system df
         rm $BUILD_ROOT/dockcross
     fi
     echo Current disk usage:

--- a/src/main/c/h3-java/build-h3.sh
+++ b/src/main/c/h3-java/build-h3.sh
@@ -21,8 +21,8 @@
 # git-ref       - Specific git ref of H3 to build.
 # use-docker    - "true" to perform cross compilation via Docker, "false" to
 #                 skip that step.
-# remove-images - If use-docker is true and this argument is true, Docker
-#                 cross compilation images will be removed after each step
+# system-prune  - If use-docker is true and this argument is true, Docker
+#                 system prune will be run after each step
 #                 (i.e. for disk space constrained environments like CI)
 # dockcross-tag - Tag name for dockcross
 #
@@ -37,7 +37,7 @@ set -ex
 GIT_REMOTE=$1
 GIT_REVISION=$2
 USE_DOCKER=$3
-REMOVE_IMAGES=$4
+SYSTEM_PRUNE=$4
 DOCKCROSS_TAG=$5
 
 echo Downloading H3 from "$GIT_REMOTE"
@@ -192,8 +192,8 @@ for image in android-arm android-arm64 linux-arm64 linux-armv5 linux-armv7 linux
     if [ -e $BUILD_ROOT/lib/libh3-java.dylib ]; then cp $BUILD_ROOT/lib/libh3-java.dylib $OUTPUT_ROOT ; fi
     if [ -e $BUILD_ROOT/lib/libh3-java.dll ]; then cp $BUILD_ROOT/lib/libh3-java.dll $OUTPUT_ROOT ; fi
 
-    if $REMOVE_IMAGES; then
-        docker rmi dockcross/$image:$DOCKCROSS_TAG
+    if $SYSTEM_PRUNE; then
+        docker system prune --force
         rm $BUILD_ROOT/dockcross
     fi
     echo Current disk usage:

--- a/src/main/c/h3-java/build-h3.sh
+++ b/src/main/c/h3-java/build-h3.sh
@@ -193,7 +193,7 @@ for image in android-arm android-arm64 linux-arm64 linux-armv5 linux-armv7 linux
     if [ -e $BUILD_ROOT/lib/libh3-java.dll ]; then cp $BUILD_ROOT/lib/libh3-java.dll $OUTPUT_ROOT ; fi
 
     if $REMOVE_IMAGES; then
-        docker rmi dockcross/$image
+        docker rmi dockcross/$image:$DOCKCROSS_TAG
         rm $BUILD_ROOT/dockcross
     fi
     echo Current disk usage:


### PR DESCRIPTION
Fixes #85. I confirmed on amazonlinux:2 Docker (https://hub.docker.com/layers/amazonlinux/library/amazonlinux/2/images/sha256-5ca9e45da788e7bac100dffaf45645cea5af68d46f62144f683c0434e14fd586?context=explore) with glibc 2.26 that this loads.

```
bash-4.2# ldd --version
ldd (GNU libc) 2.26
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Written by Roland McGrath and Ulrich Drepper.
bash-4.2# cat a.java
import com.uber.h3core.H3Core;
public class a{
public static void main(String[] args) throws Exception {
H3Core h3 = H3Core.newInstance();
System.out.println(h3.latLngToCell(0,0,0));
}
}
bash-4.2# javac a.java -cp h3-4.0.0-rc2-SNAPSHOT.jar
bash-4.2# java -cp h3-4.0.0-rc2-SNAPSHOT.jar:. a
578536630256664575
bash-4.2# java -version
openjdk version "11.0.13" 2021-10-19 LTS
OpenJDK Runtime Environment 18.9 (build 11.0.13+8-LTS)
OpenJDK 64-Bit Server VM 18.9 (build 11.0.13+8-LTS, mixed mode, sharing)
bash-4.2# javac -version
javac 11.0.13
bash-4.2# uname -a
Linux 36c0c97962e3 5.10.25-linuxkit #1 SMP Tue Mar 23 09:27:39 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux
```

I dropped support for MIPS/MIPSEL as I am not sure we have any users depending on it and the cross compilation did not immediately work. It should be possible to restore that if needed.

I also added a test for a newer version of dockcross so that we can be made aware of breaking changes in newer dockcross versions should we want to upgrade.