### PR TITLE
Tests whether the file exists

### DIFF
--- a/src/main/java/com/uber/h3core/H3CoreLoader.java
+++ b/src/main/java/com/uber/h3core/H3CoreLoader.java
@@ -111,7 +111,7 @@ public final class H3CoreLoader {
     // This is synchronized because if multiple threads were writing and
     // loading the shared object at the same time, bad things could happen.
 
-    if (libraryFile == null) {
+    if (libraryFile == null || !libraryFile.exists()) {
       final String dirName = String.format("%s-%s", os.getDirName(), arch);
       final String libName = String.format("libh3-java%s", os.getSuffix());
 


### PR DESCRIPTION
When Flink losts task node, it throws ava.lang.UnsatisfiedLinkError: Can't load library: /tmp/[libh3-java6591047064313530667.so](http://libh3-java6591047064313530667.so/)
at java.lang.ClassLoader.loadLibrary(ClassLoader.java:1820)
at java.lang.Runtime.load0(Runtime.java:810)
at java.lang.System.load(System.java:1086)
at com.uber.h3core.H3CoreLoader.loadNatives(H3CoreLoader.java:125)
at com.uber.h3core.H3CoreLoader.loadNatives(H3CoreLoader.java:89)
at com.uber.h3core.H3Core.newInstance(H3Core.java:73)
because it was deleted on task node exit.so, when new H3Core instance, need test whether libraryFile exists



