### PR TITLE
Upgrade to v4.0.0-rc4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ for the Linux x64 and Darwin x64 platforms.
 
 ## [4.0.0-rc3] - 2022-07-26
 ### Breaking Changes
-- Upgraded the core library to v4.0.0-rc4.
-- `distance` function renamed to `greatCircleDistance`.
+- Upgraded the core library to v4.0.0-rc4. (#102)
+- `distance` function renamed to `greatCircleDistance`. (#102)
 
 ## [4.0.0-rc2] - 2022-06-09
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The public API of this library consists of the public functions declared in
 file [H3Core.java](./src/main/java/com/uber/h3core/H3Core.java), and support
 for the Linux x64 and Darwin x64 platforms.
 
+## [4.0.0-rc3] - 2022-07-26
+### Breaking Changes
+- Upgraded the core library to v4.0.0-rc4.
+- `distance` function renamed to `greatCircleDistance`.
+
 ## [4.0.0-rc2] - 2022-06-09
 ### Changed
 - Required version of glibc on Linux is 2.26. (#98)

--- a/h3version.properties
+++ b/h3version.properties
@@ -1,1 +1,1 @@
-h3.git.reference=v4.0.0-rc2
+h3.git.reference=v4.0.0-rc4

--- a/src/main/c/h3-java/src/jniapi.c
+++ b/src/main/c/h3-java/src/jniapi.c
@@ -99,7 +99,7 @@ H3Error CreateGeoPolygon(JNIEnv *env, jdoubleArray verts, jintArray holeSizes,
         polygon->holes = calloc(sizeof(GeoPolygon), polygon->numHoles);
         if (polygon->holes == NULL) {
             ThrowOutOfMemoryError(env);
-            return E_MEMORY;
+            return E_MEMORY_ALLOC;
         }
 
         jint *holeSizesElements =
@@ -107,7 +107,7 @@ H3Error CreateGeoPolygon(JNIEnv *env, jdoubleArray verts, jintArray holeSizes,
         if (holeSizesElements == NULL) {
             free(polygon->holes);
             ThrowOutOfMemoryError(env);
-            return E_MEMORY;
+            return E_MEMORY_ALLOC;
         }
 
         jdouble *holeVertsElements =
@@ -117,7 +117,7 @@ H3Error CreateGeoPolygon(JNIEnv *env, jdoubleArray verts, jintArray holeSizes,
             (**env).ReleaseIntArrayElements(env, holeSizes, holeSizesElements,
                                             0);
             ThrowOutOfMemoryError(env);
-            return E_MEMORY;
+            return E_MEMORY_ALLOC;
         }
 
         size_t offset = 0;
@@ -136,7 +136,7 @@ H3Error CreateGeoPolygon(JNIEnv *env, jdoubleArray verts, jintArray holeSizes,
         return E_SUCCESS;
     } else {
         ThrowOutOfMemoryError(env);
-        return E_MEMORY;
+        return E_MEMORY_ALLOC;
     }
 }
 
@@ -905,41 +905,44 @@ JNIEXPORT jdouble JNICALL Java_com_uber_h3core_NativeMethods_cellAreaM2(
 
 /*
  * Class:     com_uber_h3core_NativeMethods
- * Method:    distanceRads
+ * Method:    greatCircleDistanceRads
  * Signature: (DDDD)D
  */
-JNIEXPORT jdouble JNICALL Java_com_uber_h3core_NativeMethods_distanceRads(
+JNIEXPORT jdouble JNICALL
+Java_com_uber_h3core_NativeMethods_greatCircleDistanceRads(
     JNIEnv *env, jobject thiz, jdouble lat1, jdouble lng1, jdouble lat2,
     jdouble lng2) {
     LatLng c1 = {.lat = lat1, .lng = lng1};
     LatLng c2 = {.lat = lat2, .lng = lng2};
-    return distanceRads(&c1, &c2);
+    return greatCircleDistanceRads(&c1, &c2);
 }
 
 /*
  * Class:     com_uber_h3core_NativeMethods
- * Method:    distanceKm
+ * Method:    greatCircleDistanceKm
  * Signature: (DDDD)D
  */
-JNIEXPORT jdouble JNICALL Java_com_uber_h3core_NativeMethods_distanceKm(
+JNIEXPORT jdouble JNICALL
+Java_com_uber_h3core_NativeMethods_greatCircleDistanceKm(
     JNIEnv *env, jobject thiz, jdouble lat1, jdouble lng1, jdouble lat2,
     jdouble lng2) {
     LatLng c1 = {.lat = lat1, .lng = lng1};
     LatLng c2 = {.lat = lat2, .lng = lng2};
-    return distanceKm(&c1, &c2);
+    return greatCircleDistanceKm(&c1, &c2);
 }
 
 /*
  * Class:     com_uber_h3core_NativeMethods
- * Method:    distanceM
+ * Method:    greatCircleDistanceM
  * Signature: (DDDD)D
  */
-JNIEXPORT jdouble JNICALL Java_com_uber_h3core_NativeMethods_distanceM(
+JNIEXPORT jdouble JNICALL
+Java_com_uber_h3core_NativeMethods_greatCircleDistanceM(
     JNIEnv *env, jobject thiz, jdouble lat1, jdouble lng1, jdouble lat2,
     jdouble lng2) {
     LatLng c1 = {.lat = lat1, .lng = lng1};
     LatLng c2 = {.lat = lat2, .lng = lng2};
-    return distanceM(&c1, &c2);
+    return greatCircleDistanceM(&c1, &c2);
 }
 
 /*

--- a/src/main/java/com/uber/h3core/H3Core.java
+++ b/src/main/java/com/uber/h3core/H3Core.java
@@ -844,15 +844,15 @@ public class H3Core {
    * @param unit Unit to return the distance in.
    * @return Distance from point <code>a</code> to point <code>b</code>
    */
-  public double distance(LatLng a, LatLng b, LengthUnit unit) {
+  public double greatCircleDistance(LatLng a, LatLng b, LengthUnit unit) {
     double lat1 = toRadians(a.lat);
     double lng1 = toRadians(a.lng);
     double lat2 = toRadians(b.lat);
     double lng2 = toRadians(b.lng);
 
-    if (unit == LengthUnit.rads) return h3Api.distanceRads(lat1, lng1, lat2, lng2);
-    else if (unit == LengthUnit.km) return h3Api.distanceKm(lat1, lng1, lat2, lng2);
-    else if (unit == LengthUnit.m) return h3Api.distanceM(lat1, lng1, lat2, lng2);
+    if (unit == LengthUnit.rads) return h3Api.greatCircleDistanceRads(lat1, lng1, lat2, lng2);
+    else if (unit == LengthUnit.km) return h3Api.greatCircleDistanceKm(lat1, lng1, lat2, lng2);
+    else if (unit == LengthUnit.m) return h3Api.greatCircleDistanceM(lat1, lng1, lat2, lng2);
     else throw new IllegalArgumentException(String.format("Invalid unit: %s", unit));
   }
 

--- a/src/main/java/com/uber/h3core/H3CoreV3.java
+++ b/src/main/java/com/uber/h3core/H3CoreV3.java
@@ -612,7 +612,7 @@ public class H3CoreV3 {
    * @return Distance from point <code>a</code> to point <code>b</code>
    */
   public double pointDist(LatLng a, LatLng b, LengthUnit unit) {
-    return h3Api.distance(a, b, unit);
+    return h3Api.greatCircleDistance(a, b, unit);
   }
 
   /**

--- a/src/main/java/com/uber/h3core/NativeMethods.java
+++ b/src/main/java/com/uber/h3core/NativeMethods.java
@@ -86,11 +86,11 @@ final class NativeMethods {
 
   native double cellAreaM2(long h3);
 
-  native double distanceRads(double lat1, double lon1, double lat2, double lon2);
+  native double greatCircleDistanceRads(double lat1, double lon1, double lat2, double lon2);
 
-  native double distanceKm(double lat1, double lon1, double lat2, double lon2);
+  native double greatCircleDistanceKm(double lat1, double lon1, double lat2, double lon2);
 
-  native double distanceM(double lat1, double lon1, double lat2, double lon2);
+  native double greatCircleDistanceM(double lat1, double lon1, double lat2, double lon2);
 
   native double exactEdgeLengthRads(long h3);
 

--- a/src/test/java/com/uber/h3core/TestMiscellaneous.java
+++ b/src/test/java/com/uber/h3core/TestMiscellaneous.java
@@ -208,9 +208,9 @@ public class TestMiscellaneous extends BaseTestH3Core {
       LatLng b = testB[i];
       double expectedRads = Math.toRadians(testDistanceDegrees[i]);
 
-      double distRads = h3.distance(a, b, LengthUnit.rads);
-      double distKm = h3.distance(a, b, LengthUnit.km);
-      double distM = h3.distance(a, b, LengthUnit.m);
+      double distRads = h3.greatCircleDistance(a, b, LengthUnit.rads);
+      double distKm = h3.greatCircleDistance(a, b, LengthUnit.km);
+      double distM = h3.greatCircleDistance(a, b, LengthUnit.m);
 
       // TODO: Epsilon is unusually large in the core H3 tests
       assertEquals("radians distance is as expected", expectedRads, distRads, EPSILON * 10000);
@@ -228,9 +228,9 @@ public class TestMiscellaneous extends BaseTestH3Core {
   public void testPointDistNaN() {
     LatLng zero = new LatLng(0, 0);
     LatLng nan = new LatLng(Double.NaN, Double.NaN);
-    double dist1 = h3.distance(nan, zero, LengthUnit.rads);
-    double dist2 = h3.distance(zero, nan, LengthUnit.km);
-    double dist3 = h3.distance(nan, nan, LengthUnit.m);
+    double dist1 = h3.greatCircleDistance(nan, zero, LengthUnit.rads);
+    double dist2 = h3.greatCircleDistance(zero, nan, LengthUnit.km);
+    double dist3 = h3.greatCircleDistance(nan, nan, LengthUnit.m);
     assertTrue("nan distance results in nan", Double.isNaN(dist1));
     assertTrue("nan distance results in nan", Double.isNaN(dist2));
     assertTrue("nan distance results in nan", Double.isNaN(dist3));
@@ -240,7 +240,7 @@ public class TestMiscellaneous extends BaseTestH3Core {
   public void testPointDistPositiveInfinity() {
     LatLng posInf = new LatLng(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
     LatLng zero = new LatLng(0, 0);
-    double dist = h3.distance(posInf, zero, LengthUnit.m);
+    double dist = h3.greatCircleDistance(posInf, zero, LengthUnit.m);
     assertTrue("+Infinity distance results in NaN", Double.isNaN(dist));
   }
 
@@ -248,7 +248,7 @@ public class TestMiscellaneous extends BaseTestH3Core {
   public void testPointDistNegativeInfinity() {
     LatLng negInf = new LatLng(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY);
     LatLng zero = new LatLng(0, 0);
-    double dist = h3.distance(negInf, zero, LengthUnit.m);
+    double dist = h3.greatCircleDistance(negInf, zero, LengthUnit.m);
     assertTrue("-Infinity distance results in NaN", Double.isNaN(dist));
   }
 
@@ -256,7 +256,7 @@ public class TestMiscellaneous extends BaseTestH3Core {
   public void testPointDistInvalid() {
     LatLng a = new LatLng(0, 0);
     LatLng b = new LatLng(0, 0);
-    h3.distance(a, b, null);
+    h3.greatCircleDistance(a, b, null);
   }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Upgrades H3-Java to the latest H3 release candidate, gaining some bug fixes and renaming the distance functions.

Note that H3-Java didn't have a 4.0.0-rc3 release, so this is the 3rd RC of H3-Java itself, which binds the 4th RC of H3 v4.