### PR TITLE
Enforce C format check in GH Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Tests
         run: mvn "-Dh3.system.prune=true" -B -V clean test site
 
+      - name: Format check for C
+        run: git diff --exit-code
+
   tests-new-dockcross:
     name: Dockcross ${{ matrix.dockcross-tag }} Java ${{ matrix.java-version }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/src/main/c/h3-java/src/jniapi.c
+++ b/src/main/c/h3-java/src/jniapi.c
@@ -950,9 +950,8 @@ Java_com_uber_h3core_NativeMethods_greatCircleDistanceM(
  * Method:    edgeLengthRads
  * Signature: (J)D
  */
-JNIEXPORT jdouble JNICALL
-Java_com_uber_h3core_NativeMethods_edgeLengthRads(JNIEnv *env,
-                                                       jobject thiz, jlong h3) {
+JNIEXPORT jdouble JNICALL Java_com_uber_h3core_NativeMethods_edgeLengthRads(
+    JNIEnv *env, jobject thiz, jlong h3) {
     jdouble out;
     H3Error err = edgeLengthRads(h3, &out);
     if (err) {


### PR DESCRIPTION
This was enforced on Java code, but not on C.

cc @nrabinowitz 