### PR TITLE
Pin dockcross version in 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ for the Linux x64 and Darwin x64 platforms.
 
 ## [Unreleased]
 
+## [3.7.3] - 2022-11-10
+### Changed
+- Required version of glibc on Linux is 2.26. (#98, #92 backported in #119)
+
+### Fixed
+- Fixed the path to Windows resources. (#109 backported in #119)
+
+### Removed
+- Removed support for Linux MIPS and MIPSEL (#98, #92 backported in #119)
+
 ## [3.7.2] - 2022-02-07
 ### Added
 - Added Apple M1 build (#89)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ H3-Java provides bindings to the H3 library, which is written in C. The built ar
 
 | Operating System | Architectures
 | ---------------- | -------------
-| Linux            | x64, x86, ARM64, ARMv5, ARMv7, MIPS, MIPSEL, PPC64LE, s390x
+| Linux            | x64, x86, ARM64, ARMv5, ARMv7, MIPS, PPC64LE, s390x
 | Windows          | x64, x86
 | Darwin (Mac OSX) | x64, ARM64
 | FreeBSD          | x64

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,8 @@
 
         <h3.git.remote>https://github.com/uber/h3.git</h3.git.remote>
         <h3.use.docker>true</h3.use.docker>
-        <h3.remove.images>false</h3.remove.images>
+        <h3.system.prune>false</h3.system.prune>
+        <h3.dockcross.tag>20210624-de7b1b0</h3.dockcross.tag>
         <!-- Used for passing additional arguments to surefire when using JaCoCo -->
         <h3.additional.argLine />
 
@@ -243,7 +244,8 @@
                                 <argument>${h3.git.remote}</argument>
                                 <argument>${h3.git.reference}</argument>
                                 <argument>${h3.use.docker}</argument>
-                                <argument>${h3.remove.images}</argument>
+                                <argument>${h3.system.prune}</argument>
+                                <argument>${h3.dockcross.tag}</argument>
                             </arguments>
                         </configuration>
                     </execution>

--- a/src/main/c/h3-java/CMakeLists.txt
+++ b/src/main/c/h3-java/CMakeLists.txt
@@ -23,9 +23,13 @@ include(CMakeDependentOption)
 
 # Needed due to CMP0042
 set(CMAKE_MACOSX_RPATH 1)
-set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cmake/toolchain.cmake"
-    CACHE FILEPATH
-    "Toolchain to use for building this project")
+if(NOT WIN32)
+    # Compiler options are set only on non-Windows, since these options
+    # are not correct for MSVC.
+    set(CMAKE_C_FLAGS_INIT "-Wall")
+    string(CONCAT CMAKE_C_FLAGS_DEBUG_INIT
+           "-g -gdwarf-2 -g3 -O0 -fno-inline -fno-eliminate-unused-debug-types")
+endif()
 set(LIBRARY_OUTPUT_PATH lib)
 set(H3_SOVERSION 1)
 

--- a/src/main/c/h3-java/build-h3-docker.sh
+++ b/src/main/c/h3-java/build-h3-docker.sh
@@ -15,8 +15,10 @@
 # limitations under the License.
 #
 
-# Arguments: [build-root]
-# build-root - Location to build the library.
+# Arguments: [build-root] [upgrade-cmake]
+# build-root    - Location to build the library.
+# upgrade-cmake - Whether to download and install a new version of CMake
+# cmake-root    - Where to download and install the new version of CMake
 #
 # Builds H3 and H3-Java in the given directory. This is intended to be
 # called from build-h3.sh as part of the cross compilation process.
@@ -24,8 +26,26 @@
 set -ex
 
 BUILD_ROOT=$1
+UPGRADE_CMAKE=$2
+CMAKE_ROOT=$3
 
-cd $BUILD_ROOT
+if $UPGRADE_CMAKE; then
+    pushd "$CMAKE_ROOT"
+    if ! [ -e cmake-3.23.2-linux-x86_64.sh ]; then
+        wget -nv https://github.com/Kitware/CMake/releases/download/v3.23.2/cmake-3.23.2-linux-x86_64.sh
+    fi
+    echo "5cca63af386e5bd0bde67c87ffac915865abd7dcc48073528f58645abda8f695  cmake-3.23.2-linux-x86_64.sh" > cmake-3.23.2-SHA-256.txt
+    sha256sum -c cmake-3.23.2-SHA-256.txt
+    if ! [ -e ./bin/cmake ]; then
+        chmod a+x cmake-3.23.2-linux-x86_64.sh
+        ./cmake-3.23.2-linux-x86_64.sh --skip-license
+    fi
+    export PATH=$(pwd)/bin:$PATH
+    cmake --version
+    popd
+fi
+
+cd "$BUILD_ROOT"
 
 mkdir -p build
 pushd build
@@ -35,6 +55,7 @@ cmake -DBUILD_SHARED_LIBS=OFF \
     -DCMAKE_C_STANDARD=99 \
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
     -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=lib \
     ../../h3
 make h3
 H3_BUILD_ROOT="$(pwd)"

--- a/src/main/c/h3-java/build-h3.sh
+++ b/src/main/c/h3-java/build-h3.sh
@@ -21,9 +21,10 @@
 # git-ref       - Specific git ref of H3 to build.
 # use-docker    - "true" to perform cross compilation via Docker, "false" to
 #                 skip that step.
-# remove-images - If use-docker is true and this argument is true, Docker
-#                 cross compilation images will be removed after each step
+# system-prune  - If use-docker is true and this argument is true, Docker
+#                 system prune will be run after each step
 #                 (i.e. for disk space constrained environments like CI)
+# dockcross-tag - Tag name for dockcross
 #
 # This script downloads H3, builds H3 and the H3-Java native library, and
 # cross compiles via Docker.
@@ -36,7 +37,8 @@ set -ex
 GIT_REMOTE=$1
 GIT_REVISION=$2
 USE_DOCKER=$3
-REMOVE_IMAGES=$4
+SYSTEM_PRUNE=$4
+DOCKCROSS_TAG=$5
 
 echo Downloading H3 from "$GIT_REMOTE"
 
@@ -156,30 +158,43 @@ if ! command -v docker; then
     exit 0
 fi
 
+# Needed for older versions of dockcross
+UPGRADE_CMAKE=true
+CMAKE_ROOT=target/cmake-3.23.2-linux-x86_64
+mkdir -p $CMAKE_ROOT
+
 # linux-armv6 excluded because of build failure
-for image in android-arm android-arm64 linux-arm64 linux-armv5 linux-armv7 linux-mipsel linux-mips linux-s390x \
-    linux-ppc64le linux-x64 linux-x86 windows-x64 windows-x86; do
+# linux-mips excluded due to manifest error
+for image in android-arm android-arm64 linux-arm64 linux-armv5 linux-armv7 linux-s390x \
+    linux-ppc64le linux-x64 linux-x86 windows-static-x64 windows-static-x86; do
 
     # Setup for using dockcross
     BUILD_ROOT=target/h3-java-build-$image
     mkdir -p $BUILD_ROOT
-    docker pull dockcross/$image
-    docker run --rm dockcross/$image > $BUILD_ROOT/dockcross
+    docker pull dockcross/$image:$DOCKCROSS_TAG
+    docker run --rm dockcross/$image:$DOCKCROSS_TAG > $BUILD_ROOT/dockcross
     chmod +x $BUILD_ROOT/dockcross
 
     # Perform the actual build inside Docker
-    $BUILD_ROOT/dockcross --args "-v $JAVA_HOME:/java" src/main/c/h3-java/build-h3-docker.sh "$BUILD_ROOT"
+    $BUILD_ROOT/dockcross --args "-v $JAVA_HOME:/java" src/main/c/h3-java/build-h3-docker.sh "$BUILD_ROOT" "$UPGRADE_CMAKE" "$CMAKE_ROOT"
 
     # Copy the built artifact into the source tree so it can be included in the
     # built JAR.
     OUTPUT_ROOT=src/main/resources/$image
+    if [ "$image" = "windows-static-x64" ]; then
+        OUTPUT_ROOT=src/main/resources/windows-x64
+    fi
+    if [ "$image" = "windows-static-x86" ]; then
+        OUTPUT_ROOT=src/main/resources/windows-x86
+    fi
     mkdir -p $OUTPUT_ROOT
     if [ -e $BUILD_ROOT/lib/libh3-java.so ]; then cp $BUILD_ROOT/lib/libh3-java.so $OUTPUT_ROOT ; fi
     if [ -e $BUILD_ROOT/lib/libh3-java.dylib ]; then cp $BUILD_ROOT/lib/libh3-java.dylib $OUTPUT_ROOT ; fi
     if [ -e $BUILD_ROOT/lib/libh3-java.dll ]; then cp $BUILD_ROOT/lib/libh3-java.dll $OUTPUT_ROOT ; fi
 
-    if $REMOVE_IMAGES; then
-        docker rmi dockcross/$image
+    if $SYSTEM_PRUNE; then
+        docker system prune --force --all
+        docker system df
         rm $BUILD_ROOT/dockcross
     fi
     echo Current disk usage:


### PR DESCRIPTION
Backports #98, #92 to `stable-3.x`. Fixes #116.