### PR TITLE
Fix Github actions artifact download script

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <groupId>com.uber</groupId>
     <artifactId>h3</artifactId>
     <packaging>jar</packaging>
-    <version>4.1.0</version>
+    <version>4.0.3-SNAPSHOT</version>
     <name>h3</name>
     <url>https://github.com/uber/h3-java</url>
     <description>Java bindings for H3, a hierarchical hexagonal geospatial indexing system.</description>
@@ -40,7 +40,7 @@
         <connection>scm:git:git://github.com/uber/h3-java.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/uber/h3-java.git</developerConnection>
         <url>http://github.com/uber/h3-java/tree/master</url>
-      <tag>v4.1.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <developers>

--- a/src/main/c/h3-java/pull-from-github.sh
+++ b/src/main/c/h3-java/pull-from-github.sh
@@ -35,6 +35,7 @@ GITHUB_ARTIFACTS_RUN=$1
 EXTRACT_TO=src/main/resources
 
 if [ -z "$GITHUB_ARTIFACTS_RUN" ]; then
+    GIT_REVISION=$(git rev-parse HEAD)
     mkdir -p target
     pushd target
 
@@ -42,9 +43,9 @@ if [ -z "$GITHUB_ARTIFACTS_RUN" ]; then
     -H "Accept: application/vnd.github+json" \
     /repos/{owner}/{repo}/actions/artifacts)
 
-    echo "downloading artifacts for run $GITHUB_ARTIFACTS_RUN"
+    echo "downloading artifacts for run $GIT_REVISION"
     TO_DOWNLOAD=$(echo "$ARTIFACTS_LIST" \
-        | jq ".artifacts[] | select(.workflow_run.id == \"$GITHUB_ARTIFACTS_RUN\")")
+        | jq ".artifacts[] | select(.workflow_run.head_sha == \"$GIT_REVISION\")")
 
     echo $TO_DOWNLOAD | jq -c '.' | while read artifactline; do
         ARTIFACT_NAME=$(echo $artifactline | jq -r .name)


### PR DESCRIPTION
This part of the script is unfortunately not tested in Github Actions (eventually we will get to automatically releasing updates through Github Actions in which case this is not needed). In the mean time here is a fix for running it locally as part of release.