### PR TITLE
use Files.createTempFile

### DIFF
--- a/.github/workflows/slack-alert.yml
+++ b/.github/workflows/slack-alert.yml
@@ -1,0 +1,22 @@
+name: slack-alert
+
+on:
+  workflow_run:
+    workflows: [tests]
+    types: [completed]
+
+jobs:
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - name: Send Slack Alert
+        id: slack
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            Github Actions ${{ github.event.workflow_run.conclusion }}
+            Repo: ${{github.event.workflow_run.repository.name }}
+            Workflow URL: ${{ github.event.workflow_run.html_url }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on:
     branches: [master, stable-*]
   pull_request:
     branches: [master, stable-*]
+  schedule:
+    # Every Sunday, rerun
+    - cron: "0 12 * * 0"
 
 jobs:
   tests:
@@ -64,7 +67,7 @@ jobs:
         os: [ubuntu-latest]
         java-distribution: [adopt]
         java-version: [17]
-        dockcross-tag: ["20220906-e88a3ce", "20230116-670f7f7"]
+        dockcross-tag: ["20230116-670f7f7", "20240529-0dade71", "latest"]
 
     steps:
       - uses: actions/checkout@v2.1.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
           if-no-files-found: error 
 
   tests-new-dockcross:
-    name: Dockcross ${{ matrix.dockcross-tag }} Java ${{ matrix.java-version }} ${{ matrix.os }}
+    name: Dockcross ${{ matrix.dockcross-tag }} Java ${{ matrix.java-version }} ${{ matrix.os }} ${{ matrix.dockcross-only }}
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -68,6 +68,7 @@ jobs:
         java-distribution: [adopt]
         java-version: [17]
         dockcross-tag: ["20230116-670f7f7", "20240418-88c04a4", "latest"]
+        dockcross-only: ["android-arm", "android-arm64", "linux-arm64", "linux-armv5", "linux-armv7", "linux-s390x", "linux-ppc64le", "linux-x64", "linux-x86", "windows-static-x64", "windows-static-x86"]
 
     steps:
       - uses: actions/checkout@v2.1.1
@@ -88,7 +89,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Tests
-        run: mvn "-Dh3.system.prune=true" "-Dh3.dockcross.tag=${{ matrix.dockcross-tag }}" -B -V clean test
+        run: mvn "-Dh3.system.prune=true" "-Dh3.dockcross.tag=${{ matrix.dockcross-tag }}" "-Dh3.dockcross.only=${{ matrix.dockcross-only }}" -B -V clean test
 
   tests-no-docker:
     name: Java (No Docker) ${{ matrix.java-version }} ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,7 +94,8 @@ jobs:
     strategy:
       matrix:
         # TODO: Docker on macos-latest running is not working
-        os: [macos-latest, windows-latest]
+        # TODO: Windows pinned back
+        os: [macos-latest, windows-2019]
         java-distribution: [adopt]
         java-version: [8, 11, 15, 17]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
         os: [ubuntu-latest]
         java-distribution: [adopt]
         java-version: [17]
-        dockcross-tag: ["20230116-670f7f7", "20240529-0dade71", "latest"]
+        dockcross-tag: ["20230116-670f7f7", "20240418-88c04a4", "latest"]
 
     steps:
       - uses: actions/checkout@v2.1.1

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <h3.use.docker>true</h3.use.docker>
         <h3.system.prune>false</h3.system.prune>
         <h3.dockcross.tag>20210624-de7b1b0</h3.dockcross.tag>
+        <h3.dockcross.only/>>
         <h3.github.artifacts.use>false</h3.github.artifacts.use>
         <h3.github.artifacts.by_run />
         <!-- Used for passing additional arguments to surefire when using JaCoCo -->
@@ -270,6 +271,7 @@
                                 <argument>${h3.use.docker}</argument>
                                 <argument>${h3.system.prune}</argument>
                                 <argument>${h3.dockcross.tag}</argument>
+                                <argument>${h3.dockcross.only}</argument>
                                 <argument>${h3.github.artifacts.use}</argument>
                                 <argument>${h3.github.artifacts.by_run}</argument>
                             </arguments>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <h3.use.docker>true</h3.use.docker>
         <h3.system.prune>false</h3.system.prune>
         <h3.dockcross.tag>20210624-de7b1b0</h3.dockcross.tag>
-        <h3.dockcross.only/>>
+        <h3.dockcross.only />
         <h3.github.artifacts.use>false</h3.github.artifacts.use>
         <h3.github.artifacts.by_run />
         <!-- Used for passing additional arguments to surefire when using JaCoCo -->

--- a/src/main/c/h3-java/build-h3.sh
+++ b/src/main/c/h3-java/build-h3.sh
@@ -25,6 +25,7 @@
 #                    system prune will be run after each step
 #                    (i.e. for disk space constrained environments like CI)
 # dockcross-tag    - Tag name for dockcross
+# dockcross-only   - When set, build only a specific architecture with dockcross.
 # github-artifacts - When set, all build artifacts are retrieved from Github
 #                    Actions artifacts rather than built locally (overrides
 #                    all other settings.)
@@ -44,8 +45,9 @@ GIT_REVISION=$2
 USE_DOCKER=$3
 SYSTEM_PRUNE=$4
 DOCKCROSS_TAG=$5
-GITHUB_ARTIFACTS=$6
-GITHUB_ARTIFACTS_RUN=$7
+DOCKCROSS_ONLY=$6
+GITHUB_ARTIFACTS=$7
+GITHUB_ARTIFACTS_RUN=$8
 
 if $GITHUB_ARTIFACTS; then
     src/main/c/h3-java/pull-from-github.sh "$GITHUB_ARTIFACTS_RUN"
@@ -180,10 +182,16 @@ UPGRADE_CMAKE=true
 CMAKE_ROOT=target/cmake-3.23.2-linux-x86_64
 mkdir -p $CMAKE_ROOT
 
+DOCKCROSS_IMAGES=android-arm android-arm64 linux-arm64 linux-armv5 linux-armv7 linux-s390x \
+    linux-ppc64le linux-x64 linux-x86 windows-static-x64 windows-static-x86
+if ! $DOCKCROSS_ONLY; then
+    DOCKCROSS_IMAGES=$DOCKCROSS_ONLY
+    echo Building only: $DOCKCROSS_IMAGES
+fi
+
 # linux-armv6 excluded because of build failure
 # linux-mips excluded due to manifest error
-for image in android-arm android-arm64 linux-arm64 linux-armv5 linux-armv7 linux-s390x \
-    linux-ppc64le linux-x64 linux-x86 windows-static-x64 windows-static-x86; do
+for image in $DOCKCROSS_IMAGES; do
 
     # Setup for using dockcross
     BUILD_ROOT=target/h3-java-build-$image

--- a/src/main/c/h3-java/build-h3.sh
+++ b/src/main/c/h3-java/build-h3.sh
@@ -210,6 +210,9 @@ for image in android-arm android-arm64 linux-arm64 linux-armv5 linux-armv7 linux
     if [ -e $BUILD_ROOT/lib/libh3-java.dll ]; then cp $BUILD_ROOT/lib/libh3-java.dll $OUTPUT_ROOT ; fi
 
     if $SYSTEM_PRUNE; then
+        # Remove the image we just ran
+        docker rmi dockcross/$image:$DOCKCROSS_TAG
+        # Aggressively try to free more disk space
         docker system prune --force --all
         docker system df
         rm $BUILD_ROOT/dockcross

--- a/src/main/c/h3-java/build-h3.sh
+++ b/src/main/c/h3-java/build-h3.sh
@@ -182,8 +182,7 @@ UPGRADE_CMAKE=true
 CMAKE_ROOT=target/cmake-3.23.2-linux-x86_64
 mkdir -p $CMAKE_ROOT
 
-DOCKCROSS_IMAGES=android-arm android-arm64 linux-arm64 linux-armv5 linux-armv7 linux-s390x \
-    linux-ppc64le linux-x64 linux-x86 windows-static-x64 windows-static-x86
+DOCKCROSS_IMAGES="android-arm android-arm64 linux-arm64 linux-armv5 linux-armv7 linux-s390x linux-ppc64le linux-x64 linux-x86 windows-static-x64 windows-static-x86"
 if ! $DOCKCROSS_ONLY; then
     DOCKCROSS_IMAGES=$DOCKCROSS_ONLY
     echo Building only: $DOCKCROSS_IMAGES

--- a/src/main/java/com/uber/h3core/H3CoreLoader.java
+++ b/src/main/java/com/uber/h3core/H3CoreLoader.java
@@ -65,6 +65,13 @@ public final class H3CoreLoader {
    * @throws UnsatisfiedLinkError The resource path does not exist
    */
   static void copyResource(String resourcePath, File newH3LibFile) throws IOException {
+    // When not a POSIX OS, try to ensure the permissions are secure.
+    // If possible, we try to create the file with the right permissions the first time in
+    // createTempLibraryFile.
+    newH3LibFile.setReadable(true, true);
+    newH3LibFile.setWritable(true, true);
+    newH3LibFile.setExecutable(true, true);
+
     // Shove the resource into the file and close it
     try (InputStream resource = H3CoreLoader.class.getResourceAsStream(resourcePath)) {
       if (resource == null) {
@@ -102,12 +109,7 @@ public final class H3CoreLoader {
           PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------"));
       return Files.createTempFile("libh3-java", os.getSuffix(), attr).toFile();
     } else {
-      // When not a POSIX OS, try to ensure the permissions are secure
-      final File f = Files.createTempFile("libh3-java", os.getSuffix()).toFile();
-      f.setReadable(true, true);
-      f.setWritable(true, true);
-      f.setExecutable(true, true);
-      return f;
+      return Files.createTempFile("libh3-java", os.getSuffix()).toFile();
     }
   }
 

--- a/src/main/java/com/uber/h3core/H3CoreLoader.java
+++ b/src/main/java/com/uber/h3core/H3CoreLoader.java
@@ -65,13 +65,6 @@ public final class H3CoreLoader {
    * @throws UnsatisfiedLinkError The resource path does not exist
    */
   static void copyResource(String resourcePath, File newH3LibFile) throws IOException {
-    // When not a POSIX OS, try to ensure the permissions are secure.
-    // If possible, we try to create the file with the right permissions the first time in
-    // createTempLibraryFile.
-    newH3LibFile.setReadable(true, true);
-    newH3LibFile.setWritable(true, true);
-    newH3LibFile.setExecutable(true, true);
-
     // Shove the resource into the file and close it
     try (InputStream resource = H3CoreLoader.class.getResourceAsStream(resourcePath)) {
       if (resource == null) {
@@ -109,7 +102,12 @@ public final class H3CoreLoader {
           PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------"));
       return Files.createTempFile("libh3-java", os.getSuffix(), attr).toFile();
     } else {
-      return Files.createTempFile("libh3-java", os.getSuffix()).toFile();
+      // When not a POSIX OS, try to ensure the permissions are secure
+      final File f = Files.createTempFile("libh3-java", os.getSuffix()).toFile();
+      f.setReadable(true, true);
+      f.setWritable(true, true);
+      f.setExecutable(true, true);
+      return f;
     }
   }
 

--- a/src/test/java/com/uber/h3core/TestH3CoreLoader.java
+++ b/src/test/java/com/uber/h3core/TestH3CoreLoader.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import org.junit.Test;
 
 /** H3CoreLoader is mostly tested by {@link TestH3CoreFactory}. This also tests OS detection. */
@@ -60,7 +61,7 @@ public class TestH3CoreLoader {
 
   @Test(expected = UnsatisfiedLinkError.class)
   public void testExtractNonexistant() throws IOException {
-    File tempFile = File.createTempFile("test-extract-resource", null);
+    File tempFile = Files.createTempFile("test-extract-resource", null).toFile();
 
     tempFile.deleteOnExit();
 


### PR DESCRIPTION
Fixes #140, using [`Files.createTempFile`](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Files.html#createTempFile-java.lang.String-java.lang.String-java.nio.file.attribute.FileAttribute...-) is preferable since it will have more restrictive permissions by default. I don't think we can rely on the file being only owner-writable since that is not in the Javadoc. From what I understand, Posix permissions will cause an exception if not supported by the OS, thus we have to check the OS.