### PR TITLE
Split CI tests with dockcross flavour and make dockross new test use only latest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   tests:
-    name: Java ${{ matrix.java-version }} ${{ matrix.os }}
+    name: Java ${{ matrix.java-version }} ${{ matrix.os }} ${{ matrix.dockcross-only }}
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -19,6 +19,7 @@ jobs:
         os: [ubuntu-latest]
         java-distribution: [adopt]
         java-version: [8, 11, 17, 21, 22]
+        dockcross-only: ["android-arm", "android-arm64", "linux-arm64", "linux-armv5", "linux-armv7", "linux-s390x", "linux-ppc64le", "linux-x64", "linux-x86", "windows-static-x64", "windows-static-x86"]
 
     steps:
       - uses: actions/checkout@v2.1.1
@@ -43,7 +44,7 @@ jobs:
         run: mvn com.spotify.fmt:fmt-maven-plugin:check
 
       - name: Tests
-        run: mvn "-Dh3.system.prune=true" -B -V clean test site
+        run: mvn "-Dh3.system.prune=true" "-Dh3.dockcross.only=${{ matrix.dockcross-only }}" -B -V clean test site
 
       - name: Format check for C
         run: git diff --exit-code
@@ -52,7 +53,7 @@ jobs:
         name: Upload artifacts
         if: ${{ matrix.java-version == 8 }}
         with:
-          name: docker-built-shared-objects
+          name: docker-built-shared-objects-${{ matrix.dockcross-only }}
           path: |
             src/main/resources/*/*.so
             src/main/resources/*/*.dll
@@ -67,7 +68,7 @@ jobs:
         os: [ubuntu-latest]
         java-distribution: [adopt]
         java-version: [21]
-        dockcross-tag: ["20230116-670f7f7", "20240418-88c04a4", "latest"]
+        dockcross-tag: ["latest"]
         dockcross-only: ["android-arm", "android-arm64", "linux-arm64", "linux-armv5", "linux-armv7", "linux-s390x", "linux-ppc64le", "linux-x64", "linux-x86", "windows-static-x64", "windows-static-x86"]
 
     steps:
@@ -201,7 +202,8 @@ jobs:
       - name: Download Docker binaries
         uses: actions/download-artifact@v4.1.7
         with:
-          name: docker-built-shared-objects
+          pattern: docker-built-shared-objects-*
+          merge-multiple: true
           path: src/main/resources/
 
       - name: Download Mac binaries


### PR DESCRIPTION
Split CI tests so we are able to bump to the the `20240812-60fa1b0` version to get improved perf on aarch64.
Also changed the `tests-new-dockcross` to use only `latest` as right now `20240812-60fa1b0` is latest so doesn't make sense to test with older versions.