### PR TITLE
Add JNI config for native image

### DIFF
--- a/src/main/resources/META-INF/native-image/com.uber/h3/jni-config.json
+++ b/src/main/resources/META-INF/native-image/com.uber/h3/jni-config.json
@@ -1,0 +1,18 @@
+[
+{
+  "name":"com.uber.h3core.exceptions.H3Exception",
+  "methods":[{"name":"<init>","parameterTypes":["int"] }]
+},
+{
+  "name":"com.uber.h3core.util.LatLng",
+  "methods":[{"name":"<init>","parameterTypes":["double","double"] }]
+},
+{
+  "name":"java.lang.OutOfMemoryError",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"java.util.ArrayList",
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"add","parameterTypes":["java.lang.Object"] }]
+}
+]

--- a/src/main/resources/META-INF/native-image/com.uber/h3/resource-config.json
+++ b/src/main/resources/META-INF/native-image/com.uber/h3/resource-config.json
@@ -1,0 +1,7 @@
+{
+  "resources": {
+    "includes": [
+      {"pattern": "**libh3-java**"}
+    ]
+  }
+}


### PR DESCRIPTION
Adds JNI config for native image, with that we are able to use the lib and compile to native image with GraalVM.
The `META-INF` `native-image` folder/files follows the [docs](https://docs.oracle.com/en/graalvm/enterprise/21/docs/reference-manual/native-image/BuildConfiguration/#embedding-a-configuration-file). All the classes accessed through JNI needs to be there, and methods as well, all existing methods are supported in native image with this new `jni-config.json` file added.

Fixes https://github.com/uber/h3-java/issues/55