### PR TITLE
Add native image tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Tests
         run: mvn "-Dh3.system.prune=true" "-Dh3.dockcross.only=${{ matrix.dockcross-only }}" -B -V clean test site
+        env:
+          OCI_EXE: docker
 
       - name: Format check for C
         run: git diff --exit-code
@@ -91,6 +93,8 @@ jobs:
 
       - name: Tests
         run: mvn "-Dh3.system.prune=true" "-Dh3.dockcross.tag=${{ matrix.dockcross-tag }}" "-Dh3.dockcross.only=${{ matrix.dockcross-only }}" -B -V clean test
+        env:
+          OCI_EXE: docker
 
   tests-no-docker:
     name: Java (No Docker) ${{ matrix.java-version }} ${{ matrix.os }}
@@ -215,5 +219,55 @@ jobs:
       - name: Download and test
         run: |
           mvn clean test -Dh3.github.artifacts.use=true -Dh3.github.artifacts.by_run=true
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+  tests-native:
+    name: Native image ${{ matrix.java-version }} ${{ matrix.os }}
+    needs:
+      - tests
+      - tests-no-docker
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+        java-distribution: [ graalvm ]
+        java-version: [ 21 ]
+
+    steps:
+      - uses: actions/checkout@v2.1.1
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "${{ matrix.java-distribution }}"
+          java-version: "${{ matrix.java-version }}"
+
+      - uses: actions/cache@v2
+        id: maven-cache
+        with:
+          path: ~/.m2/
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Download Docker binaries
+        uses: actions/download-artifact@v4.1.7
+        with:
+          pattern: docker-built-shared-objects-*
+          merge-multiple: true
+          path: src/main/resources/
+
+      - name: Download Mac binaries
+        uses: actions/download-artifact@v4.1.7
+        with:
+          name: macos-built-shared-objects
+          path: src/main/resources/
+
+      - name: Download and test
+        run: |
+          mvn clean verify -Dnative -Dh3.github.artifacts.use=true -Dh3.github.artifacts.by_run=true
         env:
           GH_TOKEN: ${{ github.token }}

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <org.openjdk.jmh.version>1.19</org.openjdk.jmh.version>
         <maven.javadoc.plugin.version>3.1.1</maven.javadoc.plugin.version>
+        <maven-surefire.version>3.5.1</maven-surefire.version>
+        <native-maven-plugin.version>0.10.3</native-maven-plugin.version>
 
         <h3.git.remote>https://github.com/uber/h3.git</h3.git.remote>
         <h3.use.docker>true</h3.use.docker>
@@ -163,15 +165,41 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>native-image</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.graalvm.buildtools</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
+                        <version>${native-maven-plugin.version}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <metadataRepository>
+                                <enabled>true</enabled>
+                            </metadataRepository>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>test-native</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>verify</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
@@ -187,7 +215,19 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>33.2.1-jre</version>
+            <version>33.3.1-jre</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>1.11.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -214,8 +254,31 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${maven-surefire.version}</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <junit.platform.listeners.uid.tracking.enabled>true</junit.platform.listeners.uid.tracking.enabled>
+                    </systemPropertyVariables>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.13.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/src/main/resources/META-INF/native-image/com.uber/h3/resource-config.json
+++ b/src/main/resources/META-INF/native-image/com.uber/h3/resource-config.json
@@ -1,7 +1,7 @@
 {
   "resources": {
     "includes": [
-      {"pattern": "**libh3-java**"}
+      {"pattern": ".*libh3-java.*"}
     ]
   }
 }

--- a/src/test/java/com/uber/h3core/BaseTestH3Core.java
+++ b/src/test/java/com/uber/h3core/BaseTestH3Core.java
@@ -16,7 +16,7 @@
 package com.uber.h3core;
 
 import java.io.IOException;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 /** Base class for tests of the class {@link H3Core} */
 public abstract class BaseTestH3Core {
@@ -24,7 +24,7 @@ public abstract class BaseTestH3Core {
 
   protected static H3Core h3;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
     h3 = H3Core.newInstance();
   }

--- a/src/test/java/com/uber/h3core/TestBindingCompleteness.java
+++ b/src/test/java/com/uber/h3core/TestBindingCompleteness.java
@@ -15,7 +15,7 @@
  */
 package com.uber.h3core;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableSet;
 import java.io.File;
@@ -24,10 +24,11 @@ import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.Scanner;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
 
 /** Tests all expected functions are exposed. */
-public class TestBindingCompleteness {
+class TestBindingCompleteness {
   /** Functions to ignore from the bindings. */
   private static final Set<String> WHITELIST =
       ImmutableSet.of(
@@ -35,7 +36,8 @@ public class TestBindingCompleteness {
           "degsToRads", "radsToDegs");
 
   @Test
-  public void test() throws IOException {
+  @DisabledInNativeImage
+  void test() throws IOException {
     Set<String> exposed = new HashSet<>();
     for (Method m : H3Core.class.getMethods()) {
       exposed.add(m.getName());
@@ -50,10 +52,10 @@ public class TestBindingCompleteness {
           continue;
         }
 
-        assertTrue(function + " is exposed in binding", exposed.contains(function));
+        assertTrue(exposed.contains(function), function + " is exposed in binding");
         checkedFunctions++;
       }
     }
-    assertTrue("Checked that the API exists", checkedFunctions > 10);
+    assertTrue(checkedFunctions > 10, "Checked that the API exists");
   }
 }

--- a/src/test/java/com/uber/h3core/TestDirectedEdges.java
+++ b/src/test/java/com/uber/h3core/TestDirectedEdges.java
@@ -15,20 +15,21 @@
  */
 package com.uber.h3core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.uber.h3core.exceptions.H3Exception;
 import com.uber.h3core.util.LatLng;
 import java.util.Collection;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for unidirectional edge functions. */
-public class TestDirectedEdges extends BaseTestH3Core {
+class TestDirectedEdges extends BaseTestH3Core {
   @Test
-  public void testUnidirectionalEdges() {
+  void unidirectionalEdges() {
     String start = "891ea6d6533ffff";
     String adjacent = "891ea6d65afffff";
     String notAdjacent = "891ea6992dbffff";
@@ -59,13 +60,14 @@ public class TestDirectedEdges extends BaseTestH3Core {
     assertEquals(2, boundary.size());
   }
 
-  @Test(expected = H3Exception.class)
-  public void testUnidirectionalEdgesNotNeighbors() {
-    h3.cellsToDirectedEdge("891ea6d6533ffff", "891ea6992dbffff");
+  @Test
+  void unidirectionalEdgesNotNeighbors() {
+    assertThrows(
+        H3Exception.class, () -> h3.cellsToDirectedEdge("891ea6d6533ffff", "891ea6992dbffff"));
   }
 
-  @Test(expected = H3Exception.class)
-  public void testDirectedEdgeInvalid() {
-    h3.getDirectedEdgeOrigin(0);
+  @Test
+  void directedEdgeInvalid() {
+    assertThrows(H3Exception.class, () -> h3.getDirectedEdgeOrigin(0));
   }
 }

--- a/src/test/java/com/uber/h3core/TestH3CoreCrossCompile.java
+++ b/src/test/java/com/uber/h3core/TestH3CoreCrossCompile.java
@@ -15,14 +15,14 @@
  */
 package com.uber.h3core;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.List;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test that particular resource names exist in the built artifact when cross compiling. Although we
@@ -30,15 +30,15 @@ import org.junit.Test;
  * that the cross compiler put resources in the right locations. This test is only run if the system
  * property <code>h3.use.docker</code> has the value <code>true</code>.
  */
-public class TestH3CoreCrossCompile {
-  @BeforeClass
-  public static void assumptions() {
+class TestH3CoreCrossCompile {
+  @BeforeAll
+  static void assumptions() {
     assumeTrue(
-        "Docker cross compilation enabled", "true".equals(System.getProperty("h3.use.docker")));
+        "true".equals(System.getProperty("h3.use.docker")), "Docker cross compilation enabled");
   }
 
   @Test
-  public void testResourcesExist() throws IOException {
+  void resourcesExist() throws IOException {
     List<String> resources =
         ImmutableList.of(
             "/linux-x64/libh3-java.so",
@@ -56,7 +56,7 @@ public class TestH3CoreCrossCompile {
             "/android-arm/libh3-java.so",
             "/android-arm64/libh3-java.so");
     for (String name : resources) {
-      assertNotNull(name + " is an included resource", H3CoreLoader.class.getResource(name));
+      assertNotNull(H3CoreLoader.class.getResource(name), name + " is an included resource");
     }
   }
 }

--- a/src/test/java/com/uber/h3core/TestH3CoreFactory.java
+++ b/src/test/java/com/uber/h3core/TestH3CoreFactory.java
@@ -15,16 +15,16 @@
  */
 package com.uber.h3core;
 
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for {@link H3Core} instantiation. */
-public class TestH3CoreFactory extends BaseTestH3Core {
+class TestH3CoreFactory extends BaseTestH3Core {
   @Test
-  public void testConstructAnother() throws IOException {
+  void constructAnother() throws IOException {
     assertNotNull(h3);
 
     H3Core another = H3Core.newInstance();
@@ -35,7 +35,7 @@ public class TestH3CoreFactory extends BaseTestH3Core {
   }
 
   @Test
-  public void testConstructSpecific() throws IOException {
+  void constructSpecific() throws IOException {
     // This uses the same logic as H3CoreLoader for detecting
     // the OS and architecture, to avoid issues with CI.
     final H3CoreLoader.OperatingSystem os =
@@ -49,7 +49,7 @@ public class TestH3CoreFactory extends BaseTestH3Core {
 
   // H3CoreV3 must be tested here due to method accessibility
   @Test
-  public void testConstructAnotherV3() throws IOException {
+  void constructAnotherV3() throws IOException {
     assertNotNull(h3);
 
     H3CoreV3 another = H3CoreV3.newInstance();
@@ -60,7 +60,7 @@ public class TestH3CoreFactory extends BaseTestH3Core {
   }
 
   @Test
-  public void testConstructSpecificV3() throws IOException {
+  void constructSpecificV3() throws IOException {
     // This uses the same logic as H3CoreLoader for detecting
     // the OS and architecture, to avoid issues with CI.
     final H3CoreLoader.OperatingSystem os =

--- a/src/test/java/com/uber/h3core/TestH3CoreLoader.java
+++ b/src/test/java/com/uber/h3core/TestH3CoreLoader.java
@@ -15,17 +15,18 @@
  */
 package com.uber.h3core;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** H3CoreLoader is mostly tested by {@link TestH3CoreFactory}. This also tests OS detection. */
-public class TestH3CoreLoader {
+class TestH3CoreLoader {
   @Test
-  public void testDetectOs() {
+  void detectOs() {
     assertEquals(
         H3CoreLoader.OperatingSystem.ANDROID, H3CoreLoader.detectOs("Android", "anything"));
     assertEquals(H3CoreLoader.OperatingSystem.DARWIN, H3CoreLoader.detectOs("vendor", "Mac OS X"));
@@ -38,7 +39,7 @@ public class TestH3CoreLoader {
   }
 
   @Test
-  public void testDetectArch() {
+  void detectArch() {
     assertEquals(H3CoreLoader.ARCH_X64, H3CoreLoader.detectArch("amd64"));
     assertEquals(H3CoreLoader.ARCH_X64, H3CoreLoader.detectArch("x86_64"));
     assertEquals(H3CoreLoader.ARCH_X64, H3CoreLoader.detectArch("x64"));
@@ -59,12 +60,12 @@ public class TestH3CoreLoader {
     assertEquals("i286", H3CoreLoader.detectArch("i286"));
   }
 
-  @Test(expected = UnsatisfiedLinkError.class)
-  public void testExtractNonexistant() throws IOException {
+  @Test
+  void extractNonexistant() throws IOException {
     File tempFile = Files.createTempFile("test-extract-resource", null).toFile();
-
     tempFile.deleteOnExit();
-
-    H3CoreLoader.copyResource("/nonexistant-resource", tempFile);
+    assertThrows(
+        UnsatisfiedLinkError.class,
+        () -> H3CoreLoader.copyResource("/nonexistant-resource", tempFile));
   }
 }

--- a/src/test/java/com/uber/h3core/TestH3CoreLoaderLocale.java
+++ b/src/test/java/com/uber/h3core/TestH3CoreLoaderLocale.java
@@ -15,37 +15,37 @@
  */
 package com.uber.h3core;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Locale;
 import javax.annotation.concurrent.NotThreadSafe;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * H3CoreLoader is mostly tested by {@link TestH3CoreFactory}. This also tests OS detection under
  * different locales.
  */
 @NotThreadSafe
-public class TestH3CoreLoaderLocale {
+class TestH3CoreLoaderLocale {
   private static Locale systemLocale;
 
-  @BeforeClass
-  public static void setup() {
+  @BeforeAll
+  static void setup() {
     systemLocale = Locale.getDefault();
     // Turkish is used as the test locale as the Turkish lower case I
     // is dotless and this frequently triggers locale-dependent bugs.
     Locale.setDefault(Locale.forLanguageTag("tr-TR"));
   }
 
-  @AfterClass
-  public static void tearDown() {
+  @AfterAll
+  static void tearDown() {
     Locale.setDefault(systemLocale);
   }
 
   @Test
-  public void testDetectOs() {
+  void detectOs() {
     assertEquals(
         H3CoreLoader.OperatingSystem.ANDROID, H3CoreLoader.detectOs("ANDROID", "anything"));
     assertEquals(H3CoreLoader.OperatingSystem.WINDOWS, H3CoreLoader.detectOs("vendor", "WINDOWS"));
@@ -57,25 +57,25 @@ public class TestH3CoreLoaderLocale {
   }
 
   @Test
-  public void testDetectArch() {
+  void detectArch() {
     assertEquals("I386", H3CoreLoader.detectArch("I386"));
   }
 
   @Test
-  public void testOsDir() {
+  void osDir() {
     assertEquals(
-        "Turkish lower case I (Darwin)",
         "darwin",
-        H3CoreLoader.OperatingSystem.DARWIN.getDirName());
+        H3CoreLoader.OperatingSystem.DARWIN.getDirName(),
+        "Turkish lower case I (Darwin)");
     assertEquals(
-        "Turkish lower case I (Linux)", "linux", H3CoreLoader.OperatingSystem.LINUX.getDirName());
+        "linux", H3CoreLoader.OperatingSystem.LINUX.getDirName(), "Turkish lower case I (Linux)");
     assertEquals(
-        "Turkish lower case I (Windows)",
         "windows",
-        H3CoreLoader.OperatingSystem.WINDOWS.getDirName());
+        H3CoreLoader.OperatingSystem.WINDOWS.getDirName(),
+        "Turkish lower case I (Windows)");
     assertEquals(
-        "Turkish lower case I (Android)",
         "android",
-        H3CoreLoader.OperatingSystem.ANDROID.getDirName());
+        H3CoreLoader.OperatingSystem.ANDROID.getDirName(),
+        "Turkish lower case I (Android)");
   }
 }

--- a/src/test/java/com/uber/h3core/TestH3CoreSystemInstance.java
+++ b/src/test/java/com/uber/h3core/TestH3CoreSystemInstance.java
@@ -15,12 +15,12 @@
  */
 package com.uber.h3core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test that {@link H3Core#newSystemInstance()} can load the H3 library. This test is only run if
@@ -29,15 +29,15 @@ import org.junit.Test;
  * installing it in a place it can be found, or setting the <code>java.library.path</code> system
  * property before starting the test JVM.
  */
-public class TestH3CoreSystemInstance {
-  @BeforeClass
-  public static void assumptions() {
+class TestH3CoreSystemInstance {
+  @BeforeAll
+  static void assumptions() {
     assumeTrue(
-        "System instance tests enabled", "true".equals(System.getProperty("h3.test.system")));
+        "true".equals(System.getProperty("h3.test.system")), "System instance tests enabled");
   }
 
   @Test
-  public void test() {
+  void test() {
     final H3Core h3 = H3Core.newSystemInstance();
     assertNotNull(h3);
     assertEquals("84194adffffffff", h3.latLngToCellAddress(51.5008796, -0.1253643, 4));

--- a/src/test/java/com/uber/h3core/TestHierarchy.java
+++ b/src/test/java/com/uber/h3core/TestHierarchy.java
@@ -15,10 +15,11 @@
  */
 package com.uber.h3core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.collect.ImmutableList;
 import com.uber.h3core.exceptions.H3Exception;
@@ -27,12 +28,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for grid hierarchy functions (compact, uncompact, children, parent) */
-public class TestHierarchy extends BaseTestH3Core {
+class TestHierarchy extends BaseTestH3Core {
   @Test
-  public void testH3ToParent() {
+  void h3ToParent() {
     assertEquals(0x801dfffffffffffL, h3.cellToParent(0x811d7ffffffffffL, 0));
     assertEquals(0x801dfffffffffffL, h3.cellToParent(0x801dfffffffffffL, 0));
     assertEquals(0x8828308281fffffL, h3.cellToParent(0x8928308280fffffL, 8));
@@ -40,28 +41,28 @@ public class TestHierarchy extends BaseTestH3Core {
     assertEquals("872830828ffffff", h3.cellToParentAddress("8928308280fffff", 7));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testH3ToParentInvalidRes() {
-    h3.cellToParent(0, 5);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testH3ToParentInvalid() {
-    h3.cellToParent(0x8928308280fffffL, -1);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testH3ToParentInvalid2() {
-    h3.cellToParent(0x8928308280fffffL, 17);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testH3ToParentInvalid3() {
-    h3.cellToParent(0, 17);
+  @Test
+  void h3ToParentInvalidRes() {
+    assertThrows(IllegalArgumentException.class, () -> h3.cellToParent(0, 5));
   }
 
   @Test
-  public void testH3ToChildren() {
+  void h3ToParentInvalid() {
+    assertThrows(IllegalArgumentException.class, () -> h3.cellToParent(0x8928308280fffffL, -1));
+  }
+
+  @Test
+  void h3ToParentInvalid2() {
+    assertThrows(IllegalArgumentException.class, () -> h3.cellToParent(0x8928308280fffffL, 17));
+  }
+
+  @Test
+  void h3ToParentInvalid3() {
+    assertThrows(IllegalArgumentException.class, () -> h3.cellToParent(0, 17));
+  }
+
+  @Test
+  void h3ToChildren() {
     List<String> sfChildren = h3.cellToChildren("88283082803ffff", 9);
 
     assertEquals(7, sfChildren.size());
@@ -98,7 +99,7 @@ public class TestHierarchy extends BaseTestH3Core {
   }
 
   @Test
-  public void testCompact() {
+  void compact() {
     // Some random location
     String starting = h3.latLngToCellAddress(30, 20, 6);
 
@@ -117,100 +118,99 @@ public class TestHierarchy extends BaseTestH3Core {
     assertEquals(new HashSet<>(expanded), new HashSet<>(uncompacted));
   }
 
-  @Test(expected = RuntimeException.class)
-  public void testCompactInvalid() {
-    // Some random location
+  @Test
+  void compactInvalid() {
     String starting = h3.latLngToCellAddress(30, 20, 6);
-
     List<String> expanded = new ArrayList<>();
     for (int i = 0; i < 8; i++) {
       expanded.add(starting);
     }
-
-    h3.compactCellAddresses(expanded);
+    assertThrows(RuntimeException.class, () -> h3.compactCellAddresses(expanded));
   }
 
   @Test
-  public void testUncompactPentagon() {
+  void uncompactPentagon() {
     List<String> addresses = h3.uncompactCellAddresses(ImmutableList.of("821c07fffffffff"), 3);
     assertEquals(6, addresses.size());
     addresses.stream().forEach(h -> assertEquals(3, h3.getResolution(h)));
   }
 
   @Test
-  public void testUncompactZero() {
+  void uncompactZero() {
     assertEquals(0, h3.uncompactCellAddresses(ImmutableList.of("0"), 3).size());
   }
 
-  @Test(expected = RuntimeException.class)
-  public void testUncompactInvalid() {
-    h3.uncompactCellAddresses(ImmutableList.of("85283473fffffff"), 4);
+  @Test
+  void uncompactInvalid() {
+    assertThrows(
+        RuntimeException.class,
+        () -> h3.uncompactCellAddresses(ImmutableList.of("85283473fffffff"), 4));
   }
 
   @Test
-  public void testH3ToCenterChild() {
+  void h3ToCenterChild() {
     assertEquals(
-        "Same resolution as parent results in same index",
         "8928308280fffff",
-        h3.cellToCenterChild("8928308280fffff", 9));
+        h3.cellToCenterChild("8928308280fffff", 9),
+        "Same resolution as parent results in same index");
     assertEquals(
-        "Same resolution as parent results in same index",
         0x8928308280fffffL,
-        h3.cellToCenterChild(0x8928308280fffffL, 9));
+        h3.cellToCenterChild(0x8928308280fffffL, 9),
+        "Same resolution as parent results in same index");
 
     assertEquals(
-        "Direct center child is correct",
         "8a28308280c7fff",
-        h3.cellToCenterChild("8928308280fffff", 10));
+        h3.cellToCenterChild("8928308280fffff", 10),
+        "Direct center child is correct");
     assertEquals(
-        "Direct center child is correct",
         0x8a28308280c7fffL,
-        h3.cellToCenterChild(0x8928308280fffffL, 10));
+        h3.cellToCenterChild(0x8928308280fffffL, 10),
+        "Direct center child is correct");
 
     assertEquals(
-        "Center child skipping a resolution is correct",
         "8b28308280c0fff",
-        h3.cellToCenterChild("8928308280fffff", 11));
+        h3.cellToCenterChild("8928308280fffff", 11),
+        "Center child skipping a resolution is correct");
     assertEquals(
-        "Center child skipping a resolution is correct",
         0x8b28308280c0fffL,
-        h3.cellToCenterChild(0x8928308280fffffL, 11));
-  }
-
-  @Test(expected = H3Exception.class)
-  public void testH3ToCenterChildParent() {
-    h3.cellToCenterChild("8928308280fffff", 8);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testH3ToCenterChildNegative() {
-    h3.cellToCenterChild("8928308280fffff", -1);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testH3ToCenterChildOutOfRange() {
-    h3.cellToCenterChild("8928308280fffff", 16);
+        h3.cellToCenterChild(0x8928308280fffffL, 11),
+        "Center child skipping a resolution is correct");
   }
 
   @Test
-  public void testCellToChildPos() {
+  void h3ToCenterChildParent() {
+    assertThrows(H3Exception.class, () -> h3.cellToCenterChild("8928308280fffff", 8));
+  }
+
+  @Test
+  void h3ToCenterChildNegative() {
+    assertThrows(IllegalArgumentException.class, () -> h3.cellToCenterChild("8928308280fffff", -1));
+  }
+
+  @Test
+  void h3ToCenterChildOutOfRange() {
+    assertThrows(IllegalArgumentException.class, () -> h3.cellToCenterChild("8928308280fffff", 16));
+  }
+
+  @Test
+  void cellToChildPos() {
     assertEquals(0, h3.cellToChildPos(0x88283080ddfffffL, 8));
     assertEquals(6, h3.cellToChildPos(0x88283080ddfffffL, 7));
     assertEquals(41, h3.cellToChildPos("88283080ddfffff", 6));
   }
 
-  @Test(expected = H3Exception.class)
-  public void testCellToChildPosError() {
-    h3.cellToChildPos(0x88283080ddfffffL, 9);
-  }
-
-  @Test(expected = H3Exception.class)
-  public void testCellToChildPosError2() {
-    h3.cellToChildPos("88283080ddfffff", 9);
+  @Test
+  void cellToChildPosError() {
+    assertThrows(H3Exception.class, () -> h3.cellToChildPos(0x88283080ddfffffL, 9));
   }
 
   @Test
-  public void childPosToCell() {
+  void cellToChildPosError2() {
+    assertThrows(H3Exception.class, () -> h3.cellToChildPos("88283080ddfffff", 9));
+  }
+
+  @Test
+  void childPosToCell() {
     assertEquals(0x88283080ddfffffL, h3.childPosToCell(0, 0x88283080ddfffffL, 8));
     assertEquals(
         0x88283080ddfffffL, h3.childPosToCell(6, h3.cellToParent(0x88283080ddfffffL, 7), 8));
@@ -218,18 +218,18 @@ public class TestHierarchy extends BaseTestH3Core {
         "88283080ddfffff", h3.childPosToCell(41, h3.cellToParentAddress("88283080ddfffff", 6), 8));
   }
 
-  @Test(expected = H3Exception.class)
-  public void testChildPosToCellError() {
-    h3.childPosToCell(-1, 0x88283080ddfffffL, 9);
-  }
-
-  @Test(expected = H3Exception.class)
-  public void testChildPosToCellError2() {
-    h3.childPosToCell(10000, "88283080ddfffff", 9);
+  @Test
+  void childPosToCellError() {
+    assertThrows(H3Exception.class, () -> h3.childPosToCell(-1, 0x88283080ddfffffL, 9));
   }
 
   @Test
-  public void cellToChildPosRoundTrip() {
+  void childPosToCellError2() {
+    assertThrows(H3Exception.class, () -> h3.childPosToCell(10000, "88283080ddfffff", 9));
+  }
+
+  @Test
+  void cellToChildPosRoundTrip() {
     // These are somewhat arbitrary, but cover a few different parts of the globe
     List<LatLng> testLatLngs =
         ImmutableList.of(
@@ -244,25 +244,25 @@ public class TestHierarchy extends BaseTestH3Core {
         long parent = h3.cellToParent(child, 0);
         long pos = h3.cellToChildPos(child, 0);
         long cell = h3.childPosToCell(pos, parent, res);
-        assertNotEquals("sanity check that pos is not a reference to child", child, pos);
-        assertEquals("round trip produced the same cell", child, cell);
+        assertNotEquals(child, pos, "sanity check that pos is not a reference to child");
+        assertEquals(child, cell, "round trip produced the same cell");
       }
     }
   }
 
   @Test
-  public void childPosAndChildrenSize() {
+  void childPosAndChildrenSize() {
     // one hexagon, one pentagon
     for (String index : ImmutableList.of("80bffffffffffff", "80a7fffffffffff")) {
       for (int res = 0; res < 16; res++) {
         long count = h3.cellToChildrenSize(index, res);
         assertTrue(
-            "count has the right order of magnitude",
-            Math.pow(6, res) <= count && count <= Math.pow(7, res));
+            Math.pow(6, res) <= count && count <= Math.pow(7, res),
+            "count has the right order of magnitude");
 
         String child = h3.childPosToCell(count - 1, index, res);
         long pos = h3.cellToChildPos(child, 0);
-        assertEquals("got expected round trip", count - 1, pos);
+        assertEquals(count - 1, pos, "got expected round trip");
 
         try {
           h3.childPosToCell(count, index, res);
@@ -275,21 +275,30 @@ public class TestHierarchy extends BaseTestH3Core {
     }
   }
 
-  @Test(expected = H3Exception.class)
-  public void cellToChildrenSizeError() {
-    // Invalid resolution
-    h3.cellToChildrenSize("88283080ddfffff", 5);
+  @Test
+  void cellToChildrenSizeError() {
+    assertThrows(
+        H3Exception.class,
+        () ->
+            // Invalid resolution
+            h3.cellToChildrenSize("88283080ddfffff", 5));
   }
 
-  @Test(expected = H3Exception.class)
-  public void cellToChildrenSizeError2() {
-    // Invalid resolution
-    h3.cellToChildrenSize(0x88283080ddfffffL, -1);
+  @Test
+  void cellToChildrenSizeError2() {
+    assertThrows(
+        H3Exception.class,
+        () ->
+            // Invalid resolution
+            h3.cellToChildrenSize(0x88283080ddfffffL, -1));
   }
 
-  @Test(expected = H3Exception.class)
-  public void cellToChildrenSizeError3() {
-    // Invalid index
-    h3.cellToChildrenSize(0xffffffffffffffffL, 9);
+  @Test
+  void cellToChildrenSizeError3() {
+    assertThrows(
+        H3Exception.class,
+        () ->
+            // Invalid index
+            h3.cellToChildrenSize(0xffffffffffffffffL, 9));
   }
 }

--- a/src/test/java/com/uber/h3core/TestIndexing.java
+++ b/src/test/java/com/uber/h3core/TestIndexing.java
@@ -15,26 +15,27 @@
  */
 package com.uber.h3core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.uber.h3core.exceptions.H3Exception;
 import com.uber.h3core.util.LatLng;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for indexing functions (geoToH3, h3ToGeo, h3ToGeoBoundary) */
-public class TestIndexing extends BaseTestH3Core {
+class TestIndexing extends BaseTestH3Core {
   @Test
-  public void testGeoToH3() {
+  void geoToH3() {
     assertEquals(h3.latLngToCell(67.194013596, 191.598258018, 5), 22758474429497343L | (1L << 59L));
   }
 
   @Test
-  public void testH3ToGeo() {
+  void h3ToGeo() {
     LatLng coords = h3.cellToLatLng(22758474429497343L | (1L << 59L));
-    assertEquals(coords.lat, 67.15092686397713, EPSILON);
+    assertEquals(67.15092686397713, coords.lat, EPSILON);
     assertEquals(coords.lng, 191.6091114190303 - 360.0, EPSILON);
 
     LatLng coords2 = h3.cellToLatLng(Long.toHexString(22758474429497343L | (1L << 59L)));
@@ -42,7 +43,7 @@ public class TestIndexing extends BaseTestH3Core {
   }
 
   @Test
-  public void testH3ToGeoBoundary() {
+  void h3ToGeoBoundary() {
     List<LatLng> boundary = h3.cellToBoundary(22758474429497343L | (1L << 59L));
     List<LatLng> actualBoundary = new ArrayList<>();
     actualBoundary.add(new LatLng(67.224749856, 191.476993415 - 360.0));
@@ -62,44 +63,48 @@ public class TestIndexing extends BaseTestH3Core {
   }
 
   @Test
-  public void testHostileInput() {
+  void hostileInput() {
     assertNotEquals(0, h3.latLngToCell(-987654321, 987654321, 5));
     assertNotEquals(0, h3.latLngToCell(987654321, -987654321, 5));
   }
 
-  @Test(expected = H3Exception.class)
-  public void testHostileGeoToH3NaN() {
-    h3.latLngToCell(Double.NaN, Double.NaN, 5);
-  }
-
-  @Test(expected = H3Exception.class)
-  public void testHostileGeoToH3PositiveInfinity() {
-    h3.latLngToCell(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, 5);
-  }
-
-  @Test(expected = H3Exception.class)
-  public void testHostileGeoToH3NegativeInfinity() {
-    h3.latLngToCell(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, 5);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testHostileInputNegativeRes() {
-    h3.latLngToCell(0, 0, -1);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testHostileInputLargeRes() {
-    h3.latLngToCell(0, 0, 1000);
+  @Test
+  void hostileGeoToH3NaN() {
+    assertThrows(H3Exception.class, () -> h3.latLngToCell(Double.NaN, Double.NaN, 5));
   }
 
   @Test
-  public void testHostileInputLatLng() {
+  void hostileGeoToH3PositiveInfinity() {
+    assertThrows(
+        H3Exception.class,
+        () -> h3.latLngToCell(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, 5));
+  }
+
+  @Test
+  void hostileGeoToH3NegativeInfinity() {
+    assertThrows(
+        H3Exception.class,
+        () -> h3.latLngToCell(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, 5));
+  }
+
+  @Test
+  void hostileInputNegativeRes() {
+    assertThrows(IllegalArgumentException.class, () -> h3.latLngToCell(0, 0, -1));
+  }
+
+  @Test
+  void hostileInputLargeRes() {
+    assertThrows(IllegalArgumentException.class, () -> h3.latLngToCell(0, 0, 1000));
+  }
+
+  @Test
+  void hostileInputLatLng() {
     // Should not crash
     h3.latLngToCell(1e45, 1e45, 0);
   }
 
   @Test
-  public void testHostileInputMaximum() {
+  void hostileInputMaximum() {
     h3.latLngToCell(Double.MAX_VALUE, Double.MAX_VALUE, 0);
   }
 }

--- a/src/test/java/com/uber/h3core/TestInspection.java
+++ b/src/test/java/com/uber/h3core/TestInspection.java
@@ -15,19 +15,19 @@
  */
 package com.uber.h3core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for index inspection and description functions. */
-public class TestInspection extends BaseTestH3Core {
+class TestInspection extends BaseTestH3Core {
   @Test
-  public void testH3IsValid() {
+  void h3IsValid() {
     assertTrue(h3.isValidCell(22758474429497343L | (1L << 59L)));
     assertFalse(h3.isValidCell(-1L));
     assertTrue(h3.isValidCell("8f28308280f18f2"));
@@ -39,7 +39,7 @@ public class TestInspection extends BaseTestH3Core {
   }
 
   @Test
-  public void testH3GetResolution() {
+  void h3GetResolution() {
     assertEquals(0, h3.getResolution(0x8029fffffffffffL));
     assertEquals(15, h3.getResolution(0x8f28308280f18f2L));
     assertEquals(14, h3.getResolution(0x8e28308280f18f7L));
@@ -51,7 +51,7 @@ public class TestInspection extends BaseTestH3Core {
   }
 
   @Test
-  public void testH3IsResClassIII() {
+  void h3IsResClassIII() {
     String r0 = h3.latLngToCellAddress(0, 0, 0);
     String r1 = h3.latLngToCellAddress(10, 0, 1);
     String r2 = h3.latLngToCellAddress(0, 10, 2);
@@ -64,7 +64,7 @@ public class TestInspection extends BaseTestH3Core {
   }
 
   @Test
-  public void testH3GetBaseCell() {
+  void h3GetBaseCell() {
     assertEquals(20, h3.getBaseCellNumber("8f28308280f18f2"));
     assertEquals(20, h3.getBaseCellNumber(0x8f28308280f18f2L));
     assertEquals(14, h3.getBaseCellNumber("821c07fffffffff"));
@@ -72,7 +72,7 @@ public class TestInspection extends BaseTestH3Core {
   }
 
   @Test
-  public void testH3IsPentagon() {
+  void h3IsPentagon() {
     assertFalse(h3.isPentagon("8f28308280f18f2"));
     assertFalse(h3.isPentagon(0x8f28308280f18f2L));
     assertTrue(h3.isPentagon("821c07fffffffff"));
@@ -80,7 +80,7 @@ public class TestInspection extends BaseTestH3Core {
   }
 
   @Test
-  public void testH3GetFaces() {
+  void h3GetFaces() {
     assertH3Faces(1, h3.getIcosahedronFaces(0x85283473fffffffL));
     assertH3Faces(1, h3.getIcosahedronFaces("85283473fffffff"));
 
@@ -90,7 +90,7 @@ public class TestInspection extends BaseTestH3Core {
   }
 
   @Test
-  public void testH3GetFacesInvalid() {
+  void h3GetFacesInvalid() {
     // Don't crash
     h3.getIcosahedronFaces(0);
   }
@@ -103,6 +103,6 @@ public class TestInspection extends BaseTestH3Core {
     }
 
     final Set<Integer> deduplicatedFaces = new HashSet<>(faces);
-    assertEquals("All faces are unique", deduplicatedFaces.size(), faces.size());
+    assertEquals(deduplicatedFaces.size(), faces.size(), "All faces are unique");
   }
 }

--- a/src/test/java/com/uber/h3core/TestMiscellaneous.java
+++ b/src/test/java/com/uber/h3core/TestMiscellaneous.java
@@ -15,18 +15,19 @@
  */
 package com.uber.h3core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.uber.h3core.exceptions.H3Exception;
 import com.uber.h3core.util.LatLng;
 import java.util.Collection;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for {@link H3Core} miscellaneous functions. */
-public class TestMiscellaneous extends BaseTestH3Core {
+class TestMiscellaneous extends BaseTestH3Core {
   @Test
-  public void testConstants() {
+  void constants() {
     double lastAreaKm2 = 0;
     double lastAreaM2 = 0;
     double lastEdgeLengthKm = 0;
@@ -57,49 +58,49 @@ public class TestMiscellaneous extends BaseTestH3Core {
   }
 
   @Test
-  public void testGetRes0Indexes() {
+  void getRes0Indexes() {
     Collection<String> indexesAddresses = h3.getRes0CellAddresses();
     Collection<Long> indexes = h3.getRes0Cells();
 
     assertEquals(
-        "Both signatures return the same results (size)", indexes.size(), indexesAddresses.size());
+        indexes.size(), indexesAddresses.size(), "Both signatures return the same results (size)");
 
     for (Long index : indexes) {
-      assertEquals("Index is unique", 1, indexes.stream().filter(i -> i.equals(index)).count());
-      assertTrue("Index is valid", h3.isValidCell(index));
-      assertEquals("Index is res 0", 0, h3.getResolution(index));
+      assertEquals(1, indexes.stream().filter(i -> i.equals(index)).count(), "Index is unique");
+      assertTrue(h3.isValidCell(index), "Index is valid");
+      assertEquals(0, h3.getResolution(index), "Index is res 0");
       assertTrue(
-          "Both signatures return the same results",
-          indexesAddresses.contains(h3.h3ToString(index)));
+          indexesAddresses.contains(h3.h3ToString(index)),
+          "Both signatures return the same results");
     }
   }
 
   @Test
-  public void testGetPentagonIndexes() {
+  void getPentagonIndexes() {
     for (int res = 0; res < 16; res++) {
       Collection<String> indexesAddresses = h3.getPentagonAddresses(res);
       Collection<Long> indexes = h3.getPentagons(res);
 
       assertEquals(
-          "Both signatures return the same results (size)",
           indexes.size(),
-          indexesAddresses.size());
-      assertEquals("There are 12 pentagons per resolution", 12, indexes.size());
+          indexesAddresses.size(),
+          "Both signatures return the same results (size)");
+      assertEquals(12, indexes.size(), "There are 12 pentagons per resolution");
 
       for (Long index : indexes) {
-        assertEquals("Index is unique", 1, indexes.stream().filter(i -> i.equals(index)).count());
-        assertTrue("Index is valid", h3.isValidCell(index));
-        assertEquals(String.format("Index is res %d", res), res, h3.getResolution(index));
+        assertEquals(1, indexes.stream().filter(i -> i.equals(index)).count(), "Index is unique");
+        assertTrue(h3.isValidCell(index), "Index is valid");
+        assertEquals(res, h3.getResolution(index), String.format("Index is res %d", res));
         assertTrue(
-            "Both signatures return the same results",
-            indexesAddresses.contains(h3.h3ToString(index)));
-        assertTrue("Index is a pentagon", h3.isPentagon(index));
+            indexesAddresses.contains(h3.h3ToString(index)),
+            "Both signatures return the same results");
+        assertTrue(h3.isPentagon(index), "Index is a pentagon");
       }
     }
   }
 
   @Test
-  public void testCellArea() {
+  void cellArea() {
     double areasKm2[] = {
       2.562182162955496e+06,
       447684.20172018633,
@@ -130,29 +131,29 @@ public class TestMiscellaneous extends BaseTestH3Core {
       double areaKm2 = h3.cellArea(cell, AreaUnit.km2);
       double areaRads2 = h3.cellArea(cell, AreaUnit.rads2);
 
-      assertEquals("cell area should match expectation", areasKm2[res], areaAddressKm2, EPSILON);
-      assertEquals("rads2 cell area should agree", areaAddressRads2, areaRads2, EPSILON);
-      assertEquals("km2 cell area should agree", areaAddressKm2, areaKm2, EPSILON);
-      assertEquals("m2 cell area should agree", areaAddressM2, areaM2, EPSILON);
-      assertTrue("m2 area greater than km2 area", areaM2 > areaKm2);
-      assertTrue("km2 area greater than rads2 area", areaKm2 > areaRads2);
+      assertEquals(areasKm2[res], areaAddressKm2, EPSILON, "cell area should match expectation");
+      assertEquals(areaAddressRads2, areaRads2, EPSILON, "rads2 cell area should agree");
+      assertEquals(areaAddressKm2, areaKm2, EPSILON, "km2 cell area should agree");
+      assertEquals(areaAddressM2, areaM2, EPSILON, "m2 cell area should agree");
+      assertTrue(areaM2 > areaKm2, "m2 area greater than km2 area");
+      assertTrue(areaKm2 > areaRads2, "km2 area greater than rads2 area");
     }
   }
 
   @Test
-  public void testCellAreaInvalid() {
+  void cellAreaInvalid() {
     // Passing in a zero should not cause a crash
     h3.cellArea(0, AreaUnit.rads2);
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testCellAreaInvalidUnit() {
+  @Test
+  void cellAreaInvalidUnit() {
     long cell = h3.latLngToCell(0, 0, 0);
-    h3.cellArea(cell, null);
+    assertThrows(IllegalArgumentException.class, () -> h3.cellArea(cell, null));
   }
 
   @Test
-  public void testEdgeLength() {
+  void edgeLength() {
     for (int res = 0; res <= 15; res++) {
       long cell = h3.latLngToCell(0, 0, res);
 
@@ -169,36 +170,39 @@ public class TestMiscellaneous extends BaseTestH3Core {
         // Only asserts some properties of the functions that the edge lengths
         // should have certain relationships to each other, test isn't specific
         // to a cell's actual values.
-        assertTrue("edge length should match expectation", areaAddressRads > 0);
-        assertEquals("rads edge length should agree", areaAddressRads, areaRads, EPSILON);
-        assertEquals("km edge length should agree", areaAddressKm, areaKm, EPSILON);
-        assertEquals("m edge length should agree", areaAddressM, areaM, EPSILON);
-        assertTrue("m length greater than km length", areaM > areaKm);
-        assertTrue("km length greater than rads length", areaKm > areaRads);
+        assertTrue(areaAddressRads > 0, "edge length should match expectation");
+        assertEquals(areaAddressRads, areaRads, EPSILON, "rads edge length should agree");
+        assertEquals(areaAddressKm, areaKm, EPSILON, "km edge length should agree");
+        assertEquals(areaAddressM, areaM, EPSILON, "m edge length should agree");
+        assertTrue(areaM > areaKm, "m length greater than km length");
+        assertTrue(areaKm > areaRads, "km length greater than rads length");
       }
     }
   }
 
-  @Test(expected = H3Exception.class)
-  public void testEdgeLengthInvalid() {
-    // Passing in a non-edge should not cause a crash
-    h3.edgeLength(h3.latLngToCell(0, 0, 0), LengthUnit.km);
-  }
-
-  @Test(expected = H3Exception.class)
-  public void testEdgeLengthInvalidEdge() {
-    h3.edgeLength(0, LengthUnit.rads);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testEdgeLengthInvalidUnit() {
-    long cell = h3.latLngToCell(0, 0, 0);
-    long edge = h3.originToDirectedEdges(cell).get(0);
-    h3.edgeLength(edge, null);
+  @Test
+  void edgeLengthInvalid() {
+    assertThrows(
+        H3Exception.class,
+        () ->
+            // Passing in a non-edge should not cause a crash
+            h3.edgeLength(h3.latLngToCell(0, 0, 0), LengthUnit.km));
   }
 
   @Test
-  public void testPointDist() {
+  void edgeLengthInvalidEdge() {
+    assertThrows(H3Exception.class, () -> h3.edgeLength(0, LengthUnit.rads));
+  }
+
+  @Test
+  void edgeLengthInvalidUnit() {
+    long cell = h3.latLngToCell(0, 0, 0);
+    long edge = h3.originToDirectedEdges(cell).get(0);
+    assertThrows(IllegalArgumentException.class, () -> h3.edgeLength(edge, null));
+  }
+
+  @Test
+  void pointDist() {
     LatLng[] testA = {new LatLng(10, 10), new LatLng(0, 0), new LatLng(23, 23)};
     LatLng[] testB = {new LatLng(10, -10), new LatLng(-10, 0), new LatLng(23, 23)};
     double[] testDistanceDegrees = {20, 10, 0};
@@ -213,79 +217,79 @@ public class TestMiscellaneous extends BaseTestH3Core {
       double distM = h3.greatCircleDistance(a, b, LengthUnit.m);
 
       // TODO: Epsilon is unusually large in the core H3 tests
-      assertEquals("radians distance is as expected", expectedRads, distRads, EPSILON * 10000);
+      assertEquals(expectedRads, distRads, EPSILON * 10000, "radians distance is as expected");
       if (expectedRads == 0) {
-        assertEquals("m distance is zero", 0, distM, EPSILON);
-        assertEquals("km distance is zero", 0, distKm, EPSILON);
+        assertEquals(0, distM, EPSILON, "m distance is zero");
+        assertEquals(0, distKm, EPSILON, "km distance is zero");
       } else {
-        assertTrue("m distance greater than km distance", distM > distKm);
-        assertTrue("km distance greater than rads distance", distKm > distRads);
+        assertTrue(distM > distKm, "m distance greater than km distance");
+        assertTrue(distKm > distRads, "km distance greater than rads distance");
       }
     }
   }
 
   @Test
-  public void testPointDistNaN() {
+  void pointDistNaN() {
     LatLng zero = new LatLng(0, 0);
     LatLng nan = new LatLng(Double.NaN, Double.NaN);
     double dist1 = h3.greatCircleDistance(nan, zero, LengthUnit.rads);
     double dist2 = h3.greatCircleDistance(zero, nan, LengthUnit.km);
     double dist3 = h3.greatCircleDistance(nan, nan, LengthUnit.m);
-    assertTrue("nan distance results in nan", Double.isNaN(dist1));
-    assertTrue("nan distance results in nan", Double.isNaN(dist2));
-    assertTrue("nan distance results in nan", Double.isNaN(dist3));
+    assertTrue(Double.isNaN(dist1), "nan distance results in nan");
+    assertTrue(Double.isNaN(dist2), "nan distance results in nan");
+    assertTrue(Double.isNaN(dist3), "nan distance results in nan");
   }
 
   @Test
-  public void testPointDistPositiveInfinity() {
+  void pointDistPositiveInfinity() {
     LatLng posInf = new LatLng(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
     LatLng zero = new LatLng(0, 0);
     double dist = h3.greatCircleDistance(posInf, zero, LengthUnit.m);
-    assertTrue("+Infinity distance results in NaN", Double.isNaN(dist));
+    assertTrue(Double.isNaN(dist), "+Infinity distance results in NaN");
   }
 
   @Test
-  public void testPointDistNegativeInfinity() {
+  void pointDistNegativeInfinity() {
     LatLng negInf = new LatLng(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY);
     LatLng zero = new LatLng(0, 0);
     double dist = h3.greatCircleDistance(negInf, zero, LengthUnit.m);
-    assertTrue("-Infinity distance results in NaN", Double.isNaN(dist));
+    assertTrue(Double.isNaN(dist), "-Infinity distance results in NaN");
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testPointDistInvalid() {
+  @Test
+  void pointDistInvalid() {
     LatLng a = new LatLng(0, 0);
     LatLng b = new LatLng(0, 0);
-    h3.greatCircleDistance(a, b, null);
+    assertThrows(IllegalArgumentException.class, () -> h3.greatCircleDistance(a, b, null));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testGetPentagonIndexesNegativeRes() {
-    h3.getPentagonAddresses(-1);
+  @Test
+  void getPentagonIndexesNegativeRes() {
+    assertThrows(IllegalArgumentException.class, () -> h3.getPentagonAddresses(-1));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testGetPentagonIndexesOutOfRangeRes() {
-    h3.getPentagonAddresses(20);
+  @Test
+  void getPentagonIndexesOutOfRangeRes() {
+    assertThrows(IllegalArgumentException.class, () -> h3.getPentagonAddresses(20));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testConstantsInvalid() {
-    h3.getHexagonAreaAvg(-1, AreaUnit.km2);
+  @Test
+  void constantsInvalid() {
+    assertThrows(IllegalArgumentException.class, () -> h3.getHexagonAreaAvg(-1, AreaUnit.km2));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testConstantsInvalidUnit() {
-    h3.getHexagonAreaAvg(-1, AreaUnit.rads2);
+  @Test
+  void constantsInvalidUnit() {
+    assertThrows(IllegalArgumentException.class, () -> h3.getHexagonAreaAvg(-1, AreaUnit.rads2));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testConstantsInvalid2() {
-    h3.getHexagonAreaAvg(0, null);
+  @Test
+  void constantsInvalid2() {
+    assertThrows(IllegalArgumentException.class, () -> h3.getHexagonAreaAvg(0, null));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testConstantsInvalid3() {
-    h3.getHexagonEdgeLengthAvg(0, null);
+  @Test
+  void constantsInvalid3() {
+    assertThrows(IllegalArgumentException.class, () -> h3.getHexagonEdgeLengthAvg(0, null));
   }
 }

--- a/src/test/java/com/uber/h3core/TestNativeMethods.java
+++ b/src/test/java/com/uber/h3core/TestNativeMethods.java
@@ -15,8 +15,9 @@
  */
 package com.uber.h3core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.uber.h3core.exceptions.H3Exception;
 import com.uber.h3core.util.LatLng;
@@ -24,21 +25,21 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /** Tests for JNI code without going through {@link H3Core}. */
-public class TestNativeMethods {
+class TestNativeMethods {
   protected static NativeMethods nativeMethods;
 
-  @BeforeClass
-  public static void setup() throws IOException {
+  @BeforeAll
+  static void setup() throws IOException {
     nativeMethods = H3CoreLoader.loadNatives();
   }
 
   /** Test that h3SetToLinkedGeo properly propagates an exception */
   @Test
-  public void testH3SetToLinkedGeoException() {
+  void h3SetToLinkedGeoException() {
     final AtomicInteger counter = new AtomicInteger(0);
 
     try {
@@ -57,19 +58,22 @@ public class TestNativeMethods {
     assertEquals(1, counter.get());
   }
 
-  @Test(expected = OutOfMemoryError.class)
-  public void getRes0IndexesTooSmall() {
-    nativeMethods.getRes0Cells(new long[1]);
+  @Test
+  void getRes0IndexesTooSmall() {
+    assertThrows(OutOfMemoryError.class, () -> nativeMethods.getRes0Cells(new long[1]));
   }
 
-  @Test(expected = OutOfMemoryError.class)
-  public void getPentagonIndexes() {
-    nativeMethods.getPentagons(1, new long[1]);
+  @Test
+  void getPentagonIndexes() {
+    assertThrows(OutOfMemoryError.class, () -> nativeMethods.getPentagons(1, new long[1]));
   }
 
-  @Test(expected = H3Exception.class)
-  public void invalidMode() {
-    nativeMethods.polygonToCells(
-        new double[] {}, new int[] {}, new double[] {}, 0, 1, new long[] {});
+  @Test
+  void invalidMode() {
+    assertThrows(
+        H3Exception.class,
+        () ->
+            nativeMethods.polygonToCells(
+                new double[] {}, new int[] {}, new double[] {}, 0, 1, new long[] {}));
   }
 }

--- a/src/test/java/com/uber/h3core/TestRegion.java
+++ b/src/test/java/com/uber/h3core/TestRegion.java
@@ -15,8 +15,9 @@
  */
 package com.uber.h3core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -24,12 +25,12 @@ import com.uber.h3core.exceptions.H3Exception;
 import com.uber.h3core.util.LatLng;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for region (polyfill, h3SetToMultiPolygon) functions. */
-public class TestRegion extends BaseTestH3Core {
+class TestRegion extends BaseTestH3Core {
   @Test
-  public void testPolyfill() {
+  void polyfill() {
     List<Long> hexagons =
         h3.polygonToCells(
             ImmutableList.of(
@@ -46,7 +47,7 @@ public class TestRegion extends BaseTestH3Core {
   }
 
   @Test
-  public void testPolyfillAddresses() {
+  void polyfillAddresses() {
     List<String> hexagons =
         h3.polygonToCellAddresses(
             ImmutableList.<LatLng>of(
@@ -63,7 +64,7 @@ public class TestRegion extends BaseTestH3Core {
   }
 
   @Test
-  public void testPolyfillWithHole() {
+  void polyfillWithHole() {
     List<Long> hexagons =
         h3.polygonToCells(
             ImmutableList.<LatLng>of(
@@ -84,7 +85,7 @@ public class TestRegion extends BaseTestH3Core {
   }
 
   @Test
-  public void testPolyfillWithTwoHoles() {
+  void polyfillWithTwoHoles() {
     List<Long> hexagons =
         h3.polygonToCells(
             ImmutableList.<LatLng>of(
@@ -109,7 +110,7 @@ public class TestRegion extends BaseTestH3Core {
   }
 
   @Test
-  public void testPolyfillKnownHoles() {
+  void polyfillKnownHoles() {
     List<Long> inputHexagons = h3.gridDisk(0x85283083fffffffL, 2);
     inputHexagons.remove(0x8528308ffffffffL);
     inputHexagons.remove(0x85283097fffffffL);
@@ -125,12 +126,12 @@ public class TestRegion extends BaseTestH3Core {
   }
 
   @Test
-  public void testH3SetToMultiPolygonEmpty() {
+  void h3SetToMultiPolygonEmpty() {
     assertEquals(0, h3.cellsToMultiPolygon(new ArrayList<Long>(), false).size());
   }
 
   @Test
-  public void testH3SetToMultiPolygonSingle() {
+  void h3SetToMultiPolygonSingle() {
     long testIndex = 0x89283082837ffffL;
 
     List<LatLng> actualBounds = h3.cellToBoundary(testIndex);
@@ -156,7 +157,7 @@ public class TestRegion extends BaseTestH3Core {
   }
 
   @Test
-  public void testH3SetToMultiPolygonSingleNonGeoJson() {
+  void h3SetToMultiPolygonSingleNonGeoJson() {
     long testIndex = 0x89283082837ffffL;
 
     List<LatLng> actualBounds = h3.cellToBoundary(testIndex);
@@ -182,7 +183,7 @@ public class TestRegion extends BaseTestH3Core {
   }
 
   @Test
-  public void testH3SetToMultiPolygonContiguous2() {
+  void h3SetToMultiPolygonContiguous2() {
     long testIndex = 0x89283082837ffffL;
     long testIndex2 = 0x89283082833ffffL;
 
@@ -220,7 +221,7 @@ public class TestRegion extends BaseTestH3Core {
   }
 
   @Test
-  public void testH3SetToMultiPolygonNonContiguous2() {
+  void h3SetToMultiPolygonNonContiguous2() {
     long testIndex = 0x89283082837ffffL;
     long testIndex2 = 0x8928308280fffffL;
 
@@ -235,7 +236,7 @@ public class TestRegion extends BaseTestH3Core {
   }
 
   @Test
-  public void testH3SetToMultiPolygonHole() {
+  void h3SetToMultiPolygonHole() {
     // Six hexagons in a ring around a hole
     List<List<List<LatLng>>> multiBounds =
         h3.cellAddressesToMultiPolygon(
@@ -255,7 +256,7 @@ public class TestRegion extends BaseTestH3Core {
   }
 
   @Test
-  public void testH3SetToMultiPolygonLarge() {
+  void h3SetToMultiPolygonLarge() {
     int numHexes = 20000;
 
     List<String> addresses = new ArrayList<>(numHexes);
@@ -272,10 +273,8 @@ public class TestRegion extends BaseTestH3Core {
     }
   }
 
-  @Test(expected = H3Exception.class)
-  public void testH3SetToMultiPolygonIssue753() {
-    // Test case reported in https://github.com/uber/h3/issues/753
-    // Ensure it does not crash
+  @Test
+  void h3SetToMultiPolygonIssue753() {
     List<Long> cells =
         ImmutableList.of(
             617683643010646015L,
@@ -382,6 +381,6 @@ public class TestRegion extends BaseTestH3Core {
             617683648067665919L,
             617683648068976639L,
             617683648028606463L);
-    h3.cellsToMultiPolygon(cells, true);
+    assertThrows(H3Exception.class, () -> h3.cellsToMultiPolygon(cells, true));
   }
 }

--- a/src/test/java/com/uber/h3core/TestTraversal.java
+++ b/src/test/java/com/uber/h3core/TestTraversal.java
@@ -15,18 +15,19 @@
  */
 package com.uber.h3core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.uber.h3core.exceptions.H3Exception;
 import com.uber.h3core.util.CoordIJ;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for grid traversal functions (k-ring, distance and line, and local IJ coordinates). */
-public class TestTraversal extends BaseTestH3Core {
+class TestTraversal extends BaseTestH3Core {
   @Test
-  public void testKring() {
+  void kring() {
     List<String> hexagons = h3.gridDisk("8928308280fffff", 1);
 
     assertEquals(1 + 6, hexagons.size());
@@ -41,7 +42,7 @@ public class TestTraversal extends BaseTestH3Core {
   }
 
   @Test
-  public void testKring2() {
+  void kring2() {
     List<String> hexagons = h3.gridDisk("8928308280fffff", 2);
 
     assertEquals(1 + 6 + 12, hexagons.size());
@@ -68,7 +69,7 @@ public class TestTraversal extends BaseTestH3Core {
   }
 
   @Test
-  public void testKringLarge() {
+  void kringLarge() {
     int k = 50;
     List<String> hexagons = h3.gridDisk("8928308280fffff", k);
 
@@ -80,15 +81,18 @@ public class TestTraversal extends BaseTestH3Core {
     assertEquals(expectedCount, hexagons.size());
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testKringTooLarge() {
+  @Test
+  void kringTooLarge() {
     int k = 13780510;
-    // Cannot be materialized into Java because the maximum array size is INT32_MAX
-    h3.gridDisk(h3.latLngToCell(0, 0, 15), k);
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            // Cannot be materialized into Java because the maximum array size is INT32_MAX
+            h3.gridDisk(h3.latLngToCell(0, 0, 15), k));
   }
 
   @Test
-  public void testKringPentagon() {
+  void kringPentagon() {
     List<String> hexagons = h3.gridDisk("821c07fffffffff", 1);
 
     assertEquals(1 + 5, hexagons.size());
@@ -102,7 +106,7 @@ public class TestTraversal extends BaseTestH3Core {
   }
 
   @Test
-  public void testHexRange() {
+  void hexRange() {
     List<List<String>> hexagons = h3.gridDiskUnsafe("8928308280fffff", 1);
 
     assertEquals(2, hexagons.size());
@@ -119,7 +123,7 @@ public class TestTraversal extends BaseTestH3Core {
   }
 
   @Test
-  public void testKRingDistances() {
+  void kRingDistances() {
     List<List<String>> hexagons = h3.gridDiskDistances("8928308280fffff", 1);
 
     assertEquals(2, hexagons.size());
@@ -136,7 +140,7 @@ public class TestTraversal extends BaseTestH3Core {
   }
 
   @Test
-  public void testHexRange2() {
+  void hexRange2() {
     List<List<String>> hexagons = h3.gridDiskDistances("8928308280fffff", 2);
 
     assertEquals(3, hexagons.size());
@@ -166,18 +170,18 @@ public class TestTraversal extends BaseTestH3Core {
   }
 
   @Test
-  public void testKRingDistancesPentagon() {
+  void kRingDistancesPentagon() {
     h3.gridDiskDistances("821c07fffffffff", 1);
     // No exception should happen
   }
 
-  @Test(expected = H3Exception.class)
-  public void testHexRangePentagon() {
-    h3.gridDiskUnsafe("821c07fffffffff", 1);
+  @Test
+  void hexRangePentagon() {
+    assertThrows(H3Exception.class, () -> h3.gridDiskUnsafe("821c07fffffffff", 1));
   }
 
   @Test
-  public void testHexRing() {
+  void hexRing() {
     List<String> hexagons = h3.gridRingUnsafe("8928308280fffff", 1);
 
     assertEquals(6, hexagons.size());
@@ -191,7 +195,7 @@ public class TestTraversal extends BaseTestH3Core {
   }
 
   @Test
-  public void testHexRing2() {
+  void hexRing2() {
     List<String> hexagons = h3.gridRingUnsafe("8928308280fffff", 2);
 
     assertEquals(12, hexagons.size());
@@ -211,7 +215,7 @@ public class TestTraversal extends BaseTestH3Core {
   }
 
   @Test
-  public void testHexRingLarge() {
+  void hexRingLarge() {
     int k = 50;
     List<String> hexagons = h3.gridRingUnsafe("8928308280fffff", k);
 
@@ -220,18 +224,18 @@ public class TestTraversal extends BaseTestH3Core {
     assertEquals(expectedCount, hexagons.size());
   }
 
-  @Test(expected = H3Exception.class)
-  public void testHexRingPentagon() {
-    h3.gridRingUnsafe("821c07fffffffff", 1);
-  }
-
-  @Test(expected = H3Exception.class)
-  public void testHexRingAroundPentagon() {
-    h3.gridRingUnsafe("821c37fffffffff", 2);
+  @Test
+  void hexRingPentagon() {
+    assertThrows(H3Exception.class, () -> h3.gridRingUnsafe("821c07fffffffff", 1));
   }
 
   @Test
-  public void testHexRingSingle() {
+  void hexRingAroundPentagon() {
+    assertThrows(H3Exception.class, () -> h3.gridRingUnsafe("821c37fffffffff", 2));
+  }
+
+  @Test
+  void hexRingSingle() {
     String origin = "8928308280fffff";
     List<String> hexagons = h3.gridRingUnsafe(origin, 0);
 
@@ -239,30 +243,39 @@ public class TestTraversal extends BaseTestH3Core {
     assertEquals("8928308280fffff", hexagons.get(0));
   }
 
-  @Test(expected = H3Exception.class)
-  public void testH3DistanceFailedDistance() {
-    // This fails because of a limitation in the H3 core library.
-    // It cannot find distances when spanning more than one base cell.
-    // Expected correct result is 2.
-    h3.gridDistance("8029fffffffffff", "8079fffffffffff");
-  }
-
-  @Test(expected = H3Exception.class)
-  public void testH3DistanceFailedResolution() {
-    // Cannot find distances when the indexes are not comparable (different resolutions)
-    h3.gridDistance("81283ffffffffff", "8029fffffffffff");
-  }
-
-  @Test(expected = H3Exception.class)
-  public void testH3DistanceFailedPentagonDistortion() {
-    // This fails because of a limitation in the H3 core library.
-    // It cannot find distances from opposite sides of a pentagon.
-    // Expected correct result is 9.
-    h3.gridDistance("821c37fffffffff", "822837fffffffff");
+  @Test
+  void h3DistanceFailedDistance() {
+    assertThrows(
+        H3Exception.class,
+        () ->
+            // This fails because of a limitation in the H3 core library.
+            // It cannot find distances when spanning more than one base cell.
+            // Expected correct result is 2.
+            h3.gridDistance("8029fffffffffff", "8079fffffffffff"));
   }
 
   @Test
-  public void testH3Distance() {
+  void h3DistanceFailedResolution() {
+    assertThrows(
+        H3Exception.class,
+        () ->
+            // Cannot find distances when the indexes are not comparable (different resolutions)
+            h3.gridDistance("81283ffffffffff", "8029fffffffffff"));
+  }
+
+  @Test
+  void h3DistanceFailedPentagonDistortion() {
+    assertThrows(
+        H3Exception.class,
+        () ->
+            // This fails because of a limitation in the H3 core library.
+            // It cannot find distances from opposite sides of a pentagon.
+            // Expected correct result is 9.
+            h3.gridDistance("821c37fffffffff", "822837fffffffff"));
+  }
+
+  @Test
+  void h3Distance() {
     // Resolution 0 to some neighbors
     assertEquals(0, h3.gridDistance("8029fffffffffff", "8029fffffffffff"));
     assertEquals(1, h3.gridDistance("8029fffffffffff", "801dfffffffffff"));
@@ -282,29 +295,32 @@ public class TestTraversal extends BaseTestH3Core {
     assertEquals(5, h3.gridDistance("85283083fffffff", "85283447fffffff"));
   }
 
-  @Test(expected = H3Exception.class)
-  public void testDistanceAcrossPentagon() {
-    // Opposite sides of a pentagon.
-    h3.gridDistance("81283ffffffffff", "811dbffffffffff");
-  }
-
-  @Test(expected = H3Exception.class)
-  public void testCellToLocalIjNoncomparable() {
-    h3.cellToLocalIj("832830fffffffff", "822837fffffffff");
-  }
-
-  @Test(expected = H3Exception.class)
-  public void testCellToLocalIjTooFar() {
-    h3.cellToLocalIj("822a17fffffffff", "822837fffffffff");
-  }
-
-  @Test(expected = H3Exception.class)
-  public void testCellToLocalIjPentagonDistortion() {
-    h3.cellToLocalIj("81283ffffffffff", "811cbffffffffff");
+  @Test
+  void distanceAcrossPentagon() {
+    assertThrows(
+        H3Exception.class,
+        () ->
+            // Opposite sides of a pentagon.
+            h3.gridDistance("81283ffffffffff", "811dbffffffffff"));
   }
 
   @Test
-  public void testCellToLocalIjPentagon() {
+  void cellToLocalIjNoncomparable() {
+    assertThrows(H3Exception.class, () -> h3.cellToLocalIj("832830fffffffff", "822837fffffffff"));
+  }
+
+  @Test
+  void cellToLocalIjTooFar() {
+    assertThrows(H3Exception.class, () -> h3.cellToLocalIj("822a17fffffffff", "822837fffffffff"));
+  }
+
+  @Test
+  void cellToLocalIjPentagonDistortion() {
+    assertThrows(H3Exception.class, () -> h3.cellToLocalIj("81283ffffffffff", "811cbffffffffff"));
+  }
+
+  @Test
+  void cellToLocalIjPentagon() {
     final String origin = "811c3ffffffffff";
     assertEquals(new CoordIJ(0, 0), h3.cellToLocalIj(origin, origin));
     assertEquals(new CoordIJ(1, 0), h3.cellToLocalIj(origin, "811d3ffffffffff"));
@@ -312,7 +328,7 @@ public class TestTraversal extends BaseTestH3Core {
   }
 
   @Test
-  public void testCellToLocalIjHexagons() {
+  void cellToLocalIjHexagons() {
     final String origin = "8828308281fffff";
     assertEquals(new CoordIJ(392, 336), h3.cellToLocalIj(origin, origin));
     assertEquals(new CoordIJ(387, 336), h3.cellToLocalIj(origin, "88283080c3fffff"));
@@ -320,20 +336,20 @@ public class TestTraversal extends BaseTestH3Core {
   }
 
   @Test
-  public void testLocalIjToCellPentagon() {
+  void localIjToCellPentagon() {
     final String origin = "811c3ffffffffff";
     assertEquals(origin, h3.localIjToCell(origin, new CoordIJ(0, 0)));
     assertEquals("811d3ffffffffff", h3.localIjToCell(origin, new CoordIJ(1, 0)));
     assertEquals("811cfffffffffff", h3.localIjToCell(origin, new CoordIJ(-1, 0)));
   }
 
-  @Test(expected = H3Exception.class)
-  public void testLocalIjToCellTooFar() {
-    h3.localIjToCell("8049fffffffffff", new CoordIJ(2, 0));
+  @Test
+  void localIjToCellTooFar() {
+    assertThrows(H3Exception.class, () -> h3.localIjToCell("8049fffffffffff", new CoordIJ(2, 0)));
   }
 
   @Test
-  public void testH3Line() {
+  void h3Line() {
     for (int res = 0; res < 12; res++) {
       String origin = h3.latLngToCellAddress(37.5, -122, res);
       String destination = h3.latLngToCellAddress(25, -120, res);
@@ -342,24 +358,23 @@ public class TestTraversal extends BaseTestH3Core {
       long distance = h3.gridDistance(origin, destination);
 
       // Need to add 1 to account for the origin as well
-      assertEquals("Distance matches expected", distance + 1, line.size());
+      assertEquals(distance + 1, line.size(), "Distance matches expected");
 
       for (int i = 1; i < line.size(); i++) {
         assertTrue(
-            "Every index in the line is a neighbor of the previous",
-            h3.areNeighborCells(line.get(i - 1), line.get(i)));
+            h3.areNeighborCells(line.get(i - 1), line.get(i)),
+            "Every index in the line is a neighbor of the previous");
       }
 
-      assertTrue("Line contains start", line.contains(origin));
-      assertTrue("Line contains destination", line.contains(destination));
+      assertTrue(line.contains(origin), "Line contains start");
+      assertTrue(line.contains(destination), "Line contains destination");
     }
   }
 
-  @Test(expected = H3Exception.class)
-  public void testH3LineFailed() {
+  @Test
+  void h3LineFailed() {
     long origin = h3.latLngToCell(37.5, -122, 9);
     long destination = h3.latLngToCell(37.5, -122, 10);
-
-    h3.gridPathCells(origin, destination);
+    assertThrows(H3Exception.class, () -> h3.gridPathCells(origin, destination));
   }
 }

--- a/src/test/java/com/uber/h3core/TestVertex.java
+++ b/src/test/java/com/uber/h3core/TestVertex.java
@@ -15,9 +15,10 @@
  */
 package com.uber.h3core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.uber.h3core.exceptions.H3Exception;
 import com.uber.h3core.util.LatLng;
@@ -25,32 +26,32 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for vertex functions */
-public class TestVertex extends BaseTestH3Core {
-  @Test(expected = H3Exception.class)
-  public void cellToVertexNegative() {
-    h3.cellToVertex(0x823d6ffffffffffL, -1);
-  }
-
-  @Test(expected = H3Exception.class)
-  public void cellToVertexTooHigh() {
-    h3.cellToVertex(0x823d6ffffffffffL, 6);
-  }
-
-  @Test(expected = H3Exception.class)
-  public void cellToVertexPentagonInvalid() {
-    h3.cellToVertex(0x823007fffffffffL, 5);
-  }
-
-  @Test(expected = H3Exception.class)
-  public void cellToVertexInvalid() {
-    h3.cellToVertex("ffffffffffffffff", 5);
+class TestVertex extends BaseTestH3Core {
+  @Test
+  void cellToVertexNegative() {
+    assertThrows(H3Exception.class, () -> h3.cellToVertex(0x823d6ffffffffffL, -1));
   }
 
   @Test
-  public void isValidVertex() {
+  void cellToVertexTooHigh() {
+    assertThrows(H3Exception.class, () -> h3.cellToVertex(0x823d6ffffffffffL, 6));
+  }
+
+  @Test
+  void cellToVertexPentagonInvalid() {
+    assertThrows(H3Exception.class, () -> h3.cellToVertex(0x823007fffffffffL, 5));
+  }
+
+  @Test
+  void cellToVertexInvalid() {
+    assertThrows(H3Exception.class, () -> h3.cellToVertex("ffffffffffffffff", 5));
+  }
+
+  @Test
+  void isValidVertex() {
     assertFalse(h3.isValidVertex(0xFFFFFFFFFFFFFFFFL));
     assertFalse(h3.isValidVertex(0));
     assertFalse(h3.isValidVertex(0x823d6ffffffffffL));
@@ -60,7 +61,7 @@ public class TestVertex extends BaseTestH3Core {
   }
 
   @Test
-  public void cellToVertexes() {
+  void cellToVertexes() {
     String origin = "823d6ffffffffff";
     Collection<String> verts = h3.cellToVertexes(origin);
     assertEquals(6, verts.size());
@@ -72,7 +73,7 @@ public class TestVertex extends BaseTestH3Core {
   }
 
   @Test
-  public void cellToVertexesPentagon() {
+  void cellToVertexesPentagon() {
     long origin = 0x823007fffffffffL;
     Collection<Long> verts = h3.cellToVertexes(origin);
     assertEquals(5, verts.size());
@@ -84,7 +85,7 @@ public class TestVertex extends BaseTestH3Core {
   }
 
   @Test
-  public void cellToVertex() {
+  void cellToVertex() {
     long origin = 0x823d6ffffffffffL;
     String originAddress = h3.h3ToString(origin);
     Set<String> verts = new HashSet<>();
@@ -95,22 +96,22 @@ public class TestVertex extends BaseTestH3Core {
       assertTrue(h3.isValidVertex(vert));
       verts.add(vertAddress);
     }
-    assertEquals("Vertexes are unique", 6, verts.size());
+    assertEquals(6, verts.size(), "Vertexes are unique");
   }
 
   @Test
-  public void vertexToLatLng() {
+  void vertexToLatLng() {
     String origin = "823d6ffffffffff";
     List<LatLng> bounds = h3.cellToBoundary(origin);
     for (int i = 0; i < 6; i++) {
       String vert = h3.cellToVertex(origin, i);
       LatLng latLng = h3.vertexToLatLng(vert);
-      assertTrue("vertex found in boundary", bounds.contains(latLng));
+      assertTrue(bounds.contains(latLng), "vertex found in boundary");
     }
   }
 
-  @Test(expected = H3Exception.class)
-  public void vertexToLatLngInvalid() {
-    h3.vertexToLatLng("ffffffffffffffff");
+  @Test
+  void vertexToLatLngInvalid() {
+    assertThrows(H3Exception.class, () -> h3.vertexToLatLng("ffffffffffffffff"));
   }
 }

--- a/src/test/java/com/uber/h3core/exceptions/TestH3Exception.java
+++ b/src/test/java/com/uber/h3core/exceptions/TestH3Exception.java
@@ -15,16 +15,16 @@
  */
 package com.uber.h3core.exceptions;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashSet;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** */
-public class TestH3Exception {
+class TestH3Exception {
   @Test
-  public void test() {
+  void test() {
     Set<String> messages = new HashSet<>();
     int maxErrorCode = 16;
     for (int i = 0; i < maxErrorCode + 10; i++) {

--- a/src/test/java/com/uber/h3core/util/TestCoordIJ.java
+++ b/src/test/java/com/uber/h3core/util/TestCoordIJ.java
@@ -15,16 +15,16 @@
  */
 package com.uber.h3core.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** */
-public class TestCoordIJ {
+class TestCoordIJ {
   @Test
-  public void test() {
+  void test() {
     CoordIJ ij1 = new CoordIJ(0, 0);
     CoordIJ ij2 = new CoordIJ(1, 10);
     CoordIJ ij3 = new CoordIJ(0, 0);
@@ -40,7 +40,7 @@ public class TestCoordIJ {
     assertNotEquals(ij3, ij2);
     assertEquals(ij1, ij3);
     assertEquals(ij1, ij1);
-    assertNotEquals(ij1, null);
+    assertNotEquals(null, ij1);
 
     assertEquals(ij1.hashCode(), ij3.hashCode());
     // Not strictly needed, but likely
@@ -48,7 +48,7 @@ public class TestCoordIJ {
   }
 
   @Test
-  public void testToString() {
+  void testToString() {
     CoordIJ ij = new CoordIJ(123, -456);
 
     String toString = ij.toString();

--- a/src/test/java/com/uber/h3core/util/TestLatLng.java
+++ b/src/test/java/com/uber/h3core/util/TestLatLng.java
@@ -15,17 +15,17 @@
  */
 package com.uber.h3core.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.uber.h3core.BaseTestH3Core;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** */
-public class TestLatLng {
+class TestLatLng {
   @Test
-  public void test() {
+  void test() {
     LatLng v1 = new LatLng(0, 1);
     LatLng v2 = new LatLng(1, 0);
     LatLng v3 = new LatLng(0, 1);
@@ -41,7 +41,7 @@ public class TestLatLng {
     assertNotEquals(v3, v2);
     assertEquals(v1, v3);
     assertEquals(v1, v1);
-    assertNotEquals(v1, null);
+    assertNotEquals(null, v1);
 
     assertEquals(v1.hashCode(), v3.hashCode());
     // Not strictly needed, but likely
@@ -49,7 +49,7 @@ public class TestLatLng {
   }
 
   @Test
-  public void testToString() {
+  void testToString() {
     LatLng v = new LatLng(123.456, 456.789);
 
     String toString = v.toString();

--- a/src/test/java/com/uber/h3core/v3/BaseTestH3CoreV3.java
+++ b/src/test/java/com/uber/h3core/v3/BaseTestH3CoreV3.java
@@ -17,7 +17,7 @@ package com.uber.h3core.v3;
 
 import com.uber.h3core.H3CoreV3;
 import java.io.IOException;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 /** Base class for tests of the class {@link H3CoreV3} */
 public abstract class BaseTestH3CoreV3 {
@@ -25,7 +25,7 @@ public abstract class BaseTestH3CoreV3 {
 
   protected static H3CoreV3 h3;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
     h3 = H3CoreV3.newInstance();
   }

--- a/src/test/java/com/uber/h3core/v3/TestDirectedEdges.java
+++ b/src/test/java/com/uber/h3core/v3/TestDirectedEdges.java
@@ -15,20 +15,21 @@
  */
 package com.uber.h3core.v3;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.uber.h3core.exceptions.H3Exception;
 import com.uber.h3core.util.LatLng;
 import java.util.Collection;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for unidirectional edge functions. */
-public class TestDirectedEdges extends BaseTestH3CoreV3 {
+class TestDirectedEdges extends BaseTestH3CoreV3 {
   @Test
-  public void testUnidirectionalEdges() {
+  void unidirectionalEdges() {
     String start = "891ea6d6533ffff";
     String adjacent = "891ea6d65afffff";
     String notAdjacent = "891ea6992dbffff";
@@ -60,7 +61,7 @@ public class TestDirectedEdges extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testUnidirectionalEdgesLong() {
+  void unidirectionalEdgesLong() {
     long start = 0x891ea6d6533ffffL;
     long adjacent = 0x891ea6d65afffffL;
     long notAdjacent = 0x891ea6992dbffffL;
@@ -91,8 +92,9 @@ public class TestDirectedEdges extends BaseTestH3CoreV3 {
     assertEquals(2, boundary.size());
   }
 
-  @Test(expected = H3Exception.class)
-  public void testUnidirectionalEdgesNotNeighbors() {
-    h3.getH3UnidirectionalEdge("891ea6d6533ffff", "891ea6992dbffff");
+  @Test
+  void unidirectionalEdgesNotNeighbors() {
+    assertThrows(
+        H3Exception.class, () -> h3.getH3UnidirectionalEdge("891ea6d6533ffff", "891ea6992dbffff"));
   }
 }

--- a/src/test/java/com/uber/h3core/v3/TestH3CoreV3SystemInstance.java
+++ b/src/test/java/com/uber/h3core/v3/TestH3CoreV3SystemInstance.java
@@ -15,13 +15,13 @@
  */
 package com.uber.h3core.v3;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.uber.h3core.H3CoreV3;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test that {@link H3CoreV3#newSystemInstance()} can load the H3 library. This test is only run if
@@ -30,15 +30,15 @@ import org.junit.Test;
  * installing it in a place it can be found, or setting the <code>java.library.path</code> system
  * property before starting the test JVM.
  */
-public class TestH3CoreV3SystemInstance {
-  @BeforeClass
-  public static void assumptions() {
+class TestH3CoreV3SystemInstance {
+  @BeforeAll
+  static void assumptions() {
     assumeTrue(
-        "System instance tests enabled", "true".equals(System.getProperty("h3.test.system")));
+        "true".equals(System.getProperty("h3.test.system")), "System instance tests enabled");
   }
 
   @Test
-  public void test() {
+  void test() {
     final H3CoreV3 h3 = H3CoreV3.newSystemInstance();
     assertNotNull(h3);
     assertEquals("84194adffffffff", h3.geoToH3Address(51.5008796, -0.1253643, 4));

--- a/src/test/java/com/uber/h3core/v3/TestHierarchy.java
+++ b/src/test/java/com/uber/h3core/v3/TestHierarchy.java
@@ -15,8 +15,9 @@
  */
 package com.uber.h3core.v3;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.uber.h3core.exceptions.H3Exception;
@@ -24,12 +25,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for grid hierarchy functions (compact, uncompact, children, parent) */
-public class TestHierarchy extends BaseTestH3CoreV3 {
+class TestHierarchy extends BaseTestH3CoreV3 {
   @Test
-  public void testH3ToParent() {
+  void h3ToParent() {
     assertEquals(0x801dfffffffffffL, h3.h3ToParent(0x811d7ffffffffffL, 0));
     assertEquals(0x801dfffffffffffL, h3.h3ToParent(0x801dfffffffffffL, 0));
     assertEquals(0x8828308281fffffL, h3.h3ToParent(0x8928308280fffffL, 8));
@@ -37,28 +38,28 @@ public class TestHierarchy extends BaseTestH3CoreV3 {
     assertEquals("872830828ffffff", h3.h3ToParentAddress("8928308280fffff", 7));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testH3ToParentInvalidRes() {
-    h3.h3ToParent(0, 5);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testH3ToParentInvalid() {
-    h3.h3ToParent(0x8928308280fffffL, -1);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testH3ToParentInvalid2() {
-    h3.h3ToParent(0x8928308280fffffL, 17);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testH3ToParentInvalid3() {
-    h3.h3ToParent(0, 17);
+  @Test
+  void h3ToParentInvalidRes() {
+    assertThrows(IllegalArgumentException.class, () -> h3.h3ToParent(0, 5));
   }
 
   @Test
-  public void testH3ToChildren() {
+  void h3ToParentInvalid() {
+    assertThrows(IllegalArgumentException.class, () -> h3.h3ToParent(0x8928308280fffffL, -1));
+  }
+
+  @Test
+  void h3ToParentInvalid2() {
+    assertThrows(IllegalArgumentException.class, () -> h3.h3ToParent(0x8928308280fffffL, 17));
+  }
+
+  @Test
+  void h3ToParentInvalid3() {
+    assertThrows(IllegalArgumentException.class, () -> h3.h3ToParent(0, 17));
+  }
+
+  @Test
+  void h3ToChildren() {
     List<String> sfChildren = h3.h3ToChildren("88283082803ffff", 9);
 
     assertEquals(7, sfChildren.size());
@@ -95,7 +96,7 @@ public class TestHierarchy extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testCompact() {
+  void compact() {
     // Some random location
     String starting = h3.geoToH3Address(30, 20, 6);
 
@@ -115,7 +116,7 @@ public class TestHierarchy extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testCompactLong() {
+  void compactLong() {
     // Some random location
     long starting = h3.geoToH3(30, 20, 6);
 
@@ -134,78 +135,76 @@ public class TestHierarchy extends BaseTestH3CoreV3 {
     assertEquals(new HashSet<>(expanded), new HashSet<>(uncompacted));
   }
 
-  @Test(expected = RuntimeException.class)
-  public void testCompactInvalid() {
-    // Some random location
+  @Test
+  void compactInvalid() {
     String starting = h3.geoToH3Address(30, 20, 6);
-
     List<String> expanded = new ArrayList<>();
     for (int i = 0; i < 8; i++) {
       expanded.add(starting);
     }
-
-    h3.compactAddress(expanded);
+    assertThrows(RuntimeException.class, () -> h3.compactAddress(expanded));
   }
 
   @Test
-  public void testUncompactPentagon() {
+  void uncompactPentagon() {
     List<String> addresses = h3.uncompactAddress(ImmutableList.of("821c07fffffffff"), 3);
     assertEquals(6, addresses.size());
     addresses.stream().forEach(h -> assertEquals(3, h3.h3GetResolution(h)));
   }
 
   @Test
-  public void testUncompactZero() {
+  void uncompactZero() {
     assertEquals(0, h3.uncompactAddress(ImmutableList.of("0"), 3).size());
   }
 
-  @Test(expected = RuntimeException.class)
-  public void testUncompactInvalid() {
-    h3.uncompactAddress(ImmutableList.of("85283473fffffff"), 4);
+  @Test
+  void uncompactInvalid() {
+    assertThrows(
+        RuntimeException.class, () -> h3.uncompactAddress(ImmutableList.of("85283473fffffff"), 4));
   }
 
   @Test
-  public void testH3ToCenterChild() {
+  void h3ToCenterChild() {
     assertEquals(
-        "Same resolution as parent results in same index",
         "8928308280fffff",
-        h3.h3ToCenterChild("8928308280fffff", 9));
+        h3.h3ToCenterChild("8928308280fffff", 9),
+        "Same resolution as parent results in same index");
     assertEquals(
-        "Same resolution as parent results in same index",
         0x8928308280fffffL,
-        h3.h3ToCenterChild(0x8928308280fffffL, 9));
+        h3.h3ToCenterChild(0x8928308280fffffL, 9),
+        "Same resolution as parent results in same index");
 
     assertEquals(
-        "Direct center child is correct",
         "8a28308280c7fff",
-        h3.h3ToCenterChild("8928308280fffff", 10));
+        h3.h3ToCenterChild("8928308280fffff", 10),
+        "Direct center child is correct");
     assertEquals(
-        "Direct center child is correct",
         0x8a28308280c7fffL,
-        h3.h3ToCenterChild(0x8928308280fffffL, 10));
+        h3.h3ToCenterChild(0x8928308280fffffL, 10),
+        "Direct center child is correct");
 
     assertEquals(
-        "Center child skipping a resolution is correct",
         "8b28308280c0fff",
-        h3.h3ToCenterChild("8928308280fffff", 11));
+        h3.h3ToCenterChild("8928308280fffff", 11),
+        "Center child skipping a resolution is correct");
     assertEquals(
-        "Center child skipping a resolution is correct",
         0x8b28308280c0fffL,
-        h3.h3ToCenterChild(0x8928308280fffffL, 11));
+        h3.h3ToCenterChild(0x8928308280fffffL, 11),
+        "Center child skipping a resolution is correct");
   }
 
-  @Test(expected = H3Exception.class)
-  public void testH3ToCenterChildParent() {
-    h3.h3ToCenterChild("8928308280fffff", 8);
+  @Test
+  void h3ToCenterChildParent() {
+    assertThrows(H3Exception.class, () -> h3.h3ToCenterChild("8928308280fffff", 8));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testH3ToCenterChildNegative() {
-    h3.h3ToCenterChild("8928308280fffff", -1);
+  @Test
+  void h3ToCenterChildNegative() {
+    assertThrows(IllegalArgumentException.class, () -> h3.h3ToCenterChild("8928308280fffff", -1));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testH3ToCenterChildOutOfRange() {
-    h3.h3ToCenterChild("8928308280fffff", 16);
+  @Test
+  void h3ToCenterChildOutOfRange() {
+    assertThrows(IllegalArgumentException.class, () -> h3.h3ToCenterChild("8928308280fffff", 16));
   }
 }

--- a/src/test/java/com/uber/h3core/v3/TestIndexing.java
+++ b/src/test/java/com/uber/h3core/v3/TestIndexing.java
@@ -15,26 +15,27 @@
  */
 package com.uber.h3core.v3;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.uber.h3core.exceptions.H3Exception;
 import com.uber.h3core.util.LatLng;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for indexing functions (geoToH3, h3ToGeo, h3ToGeoBoundary) */
-public class TestIndexing extends BaseTestH3CoreV3 {
+class TestIndexing extends BaseTestH3CoreV3 {
   @Test
-  public void testGeoToH3() {
+  void geoToH3() {
     assertEquals(h3.geoToH3(67.194013596, 191.598258018, 5), 22758474429497343L | (1L << 59L));
   }
 
   @Test
-  public void testH3ToGeo() {
+  void h3ToGeo() {
     LatLng coords = h3.h3ToGeo(22758474429497343L | (1L << 59L));
-    assertEquals(coords.lat, 67.15092686397713, EPSILON);
+    assertEquals(67.15092686397713, coords.lat, EPSILON);
     assertEquals(coords.lng, 191.6091114190303 - 360.0, EPSILON);
 
     LatLng coords2 = h3.h3ToGeo(Long.toHexString(22758474429497343L | (1L << 59L)));
@@ -42,7 +43,7 @@ public class TestIndexing extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testH3ToGeoBoundary() {
+  void h3ToGeoBoundary() {
     List<LatLng> boundary = h3.h3ToGeoBoundary(22758474429497343L | (1L << 59L));
     List<LatLng> actualBoundary = new ArrayList<>();
     actualBoundary.add(new LatLng(67.224749856, 191.476993415 - 360.0));
@@ -62,44 +63,46 @@ public class TestIndexing extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testHostileInput() {
+  void hostileInput() {
     assertNotEquals(0, h3.geoToH3(-987654321, 987654321, 5));
     assertNotEquals(0, h3.geoToH3(987654321, -987654321, 5));
   }
 
-  @Test(expected = H3Exception.class)
-  public void testHostileGeoToH3NaN() {
-    h3.geoToH3(Double.NaN, Double.NaN, 5);
-  }
-
-  @Test(expected = H3Exception.class)
-  public void testHostileGeoToH3PositiveInfinity() {
-    h3.geoToH3(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, 5);
-  }
-
-  @Test(expected = H3Exception.class)
-  public void testHostileGeoToH3NegativeInfinity() {
-    h3.geoToH3(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, 5);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testHostileInputNegativeRes() {
-    h3.geoToH3(0, 0, -1);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testHostileInputLargeRes() {
-    h3.geoToH3(0, 0, 1000);
+  @Test
+  void hostileGeoToH3NaN() {
+    assertThrows(H3Exception.class, () -> h3.geoToH3(Double.NaN, Double.NaN, 5));
   }
 
   @Test
-  public void testHostileInputLatLng() {
+  void hostileGeoToH3PositiveInfinity() {
+    assertThrows(
+        H3Exception.class, () -> h3.geoToH3(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, 5));
+  }
+
+  @Test
+  void hostileGeoToH3NegativeInfinity() {
+    assertThrows(
+        H3Exception.class, () -> h3.geoToH3(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, 5));
+  }
+
+  @Test
+  void hostileInputNegativeRes() {
+    assertThrows(IllegalArgumentException.class, () -> h3.geoToH3(0, 0, -1));
+  }
+
+  @Test
+  void hostileInputLargeRes() {
+    assertThrows(IllegalArgumentException.class, () -> h3.geoToH3(0, 0, 1000));
+  }
+
+  @Test
+  void hostileInputLatLng() {
     // Should not crash
     h3.geoToH3(1e45, 1e45, 0);
   }
 
   @Test
-  public void testHostileInputMaximum() {
+  void hostileInputMaximum() {
     h3.geoToH3(Double.MAX_VALUE, Double.MAX_VALUE, 0);
   }
 }

--- a/src/test/java/com/uber/h3core/v3/TestInspection.java
+++ b/src/test/java/com/uber/h3core/v3/TestInspection.java
@@ -15,19 +15,19 @@
  */
 package com.uber.h3core.v3;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for index inspection and description functions. */
-public class TestInspection extends BaseTestH3CoreV3 {
+class TestInspection extends BaseTestH3CoreV3 {
   @Test
-  public void testH3IsValid() {
+  void h3IsValid() {
     assertTrue(h3.h3IsValid(22758474429497343L | (1L << 59L)));
     assertFalse(h3.h3IsValid(-1L));
     assertTrue(h3.h3IsValid("8f28308280f18f2"));
@@ -39,7 +39,7 @@ public class TestInspection extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testH3GetResolution() {
+  void h3GetResolution() {
     assertEquals(0, h3.h3GetResolution(0x8029fffffffffffL));
     assertEquals(15, h3.h3GetResolution(0x8f28308280f18f2L));
     assertEquals(14, h3.h3GetResolution(0x8e28308280f18f7L));
@@ -51,7 +51,7 @@ public class TestInspection extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testH3IsResClassIII() {
+  void h3IsResClassIII() {
     String r0 = h3.geoToH3Address(0, 0, 0);
     String r1 = h3.geoToH3Address(10, 0, 1);
     long r2 = h3.geoToH3(0, 10, 2);
@@ -64,7 +64,7 @@ public class TestInspection extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testH3GetBaseCell() {
+  void h3GetBaseCell() {
     assertEquals(20, h3.h3GetBaseCell("8f28308280f18f2"));
     assertEquals(20, h3.h3GetBaseCell(0x8f28308280f18f2L));
     assertEquals(14, h3.h3GetBaseCell("821c07fffffffff"));
@@ -72,7 +72,7 @@ public class TestInspection extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testH3IsPentagon() {
+  void h3IsPentagon() {
     assertFalse(h3.h3IsPentagon("8f28308280f18f2"));
     assertFalse(h3.h3IsPentagon(0x8f28308280f18f2L));
     assertTrue(h3.h3IsPentagon("821c07fffffffff"));
@@ -80,7 +80,7 @@ public class TestInspection extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testH3GetFaces() {
+  void h3GetFaces() {
     assertH3Faces(1, h3.h3GetFaces(0x85283473fffffffL));
     assertH3Faces(1, h3.h3GetFaces("85283473fffffff"));
 
@@ -90,7 +90,7 @@ public class TestInspection extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testH3GetFacesInvalid() {
+  void h3GetFacesInvalid() {
     // Don't crash
     h3.h3GetFaces(0);
   }
@@ -103,6 +103,6 @@ public class TestInspection extends BaseTestH3CoreV3 {
     }
 
     final Set<Integer> deduplicatedFaces = new HashSet<>(faces);
-    assertEquals("All faces are unique", deduplicatedFaces.size(), faces.size());
+    assertEquals(deduplicatedFaces.size(), faces.size(), "All faces are unique");
   }
 }

--- a/src/test/java/com/uber/h3core/v3/TestMiscellaneous.java
+++ b/src/test/java/com/uber/h3core/v3/TestMiscellaneous.java
@@ -15,20 +15,21 @@
  */
 package com.uber.h3core.v3;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.uber.h3core.AreaUnit;
 import com.uber.h3core.LengthUnit;
 import com.uber.h3core.exceptions.H3Exception;
 import com.uber.h3core.util.LatLng;
 import java.util.Collection;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for {@link com.uber.h3core.H3CoreV3} instantiation and miscellaneous functions. */
-public class TestMiscellaneous extends BaseTestH3CoreV3 {
+class TestMiscellaneous extends BaseTestH3CoreV3 {
   @Test
-  public void testConstants() {
+  void constants() {
     double lastAreaKm2 = 0;
     double lastAreaM2 = 0;
     double lastEdgeLengthKm = 0;
@@ -59,49 +60,49 @@ public class TestMiscellaneous extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testGetRes0Indexes() {
+  void getRes0Indexes() {
     Collection<String> indexesAddresses = h3.getRes0IndexesAddresses();
     Collection<Long> indexes = h3.getRes0Indexes();
 
     assertEquals(
-        "Both signatures return the same results (size)", indexes.size(), indexesAddresses.size());
+        indexes.size(), indexesAddresses.size(), "Both signatures return the same results (size)");
 
     for (Long index : indexes) {
-      assertEquals("Index is unique", 1, indexes.stream().filter(i -> i.equals(index)).count());
-      assertTrue("Index is valid", h3.h3IsValid(index));
-      assertEquals("Index is res 0", 0, h3.h3GetResolution(index));
+      assertEquals(1, indexes.stream().filter(i -> i.equals(index)).count(), "Index is unique");
+      assertTrue(h3.h3IsValid(index), "Index is valid");
+      assertEquals(0, h3.h3GetResolution(index), "Index is res 0");
       assertTrue(
-          "Both signatures return the same results",
-          indexesAddresses.contains(h3.h3ToString(index)));
+          indexesAddresses.contains(h3.h3ToString(index)),
+          "Both signatures return the same results");
     }
   }
 
   @Test
-  public void testGetPentagonIndexes() {
+  void getPentagonIndexes() {
     for (int res = 0; res < 16; res++) {
       Collection<String> indexesAddresses = h3.getPentagonIndexesAddresses(res);
       Collection<Long> indexes = h3.getPentagonIndexes(res);
 
       assertEquals(
-          "Both signatures return the same results (size)",
           indexes.size(),
-          indexesAddresses.size());
-      assertEquals("There are 12 pentagons per resolution", 12, indexes.size());
+          indexesAddresses.size(),
+          "Both signatures return the same results (size)");
+      assertEquals(12, indexes.size(), "There are 12 pentagons per resolution");
 
       for (Long index : indexes) {
-        assertEquals("Index is unique", 1, indexes.stream().filter(i -> i.equals(index)).count());
-        assertTrue("Index is valid", h3.h3IsValid(index));
-        assertEquals(String.format("Index is res %d", res), res, h3.h3GetResolution(index));
+        assertEquals(1, indexes.stream().filter(i -> i.equals(index)).count(), "Index is unique");
+        assertTrue(h3.h3IsValid(index), "Index is valid");
+        assertEquals(res, h3.h3GetResolution(index), String.format("Index is res %d", res));
         assertTrue(
-            "Both signatures return the same results",
-            indexesAddresses.contains(h3.h3ToString(index)));
-        assertTrue("Index is a pentagon", h3.h3IsPentagon(index));
+            indexesAddresses.contains(h3.h3ToString(index)),
+            "Both signatures return the same results");
+        assertTrue(h3.h3IsPentagon(index), "Index is a pentagon");
       }
     }
   }
 
   @Test
-  public void testCellArea() {
+  void cellArea() {
     double areasKm2[] = {
       2.562182162955496e+06,
       447684.20172018633,
@@ -132,29 +133,29 @@ public class TestMiscellaneous extends BaseTestH3CoreV3 {
       double areaKm2 = h3.cellArea(cell, AreaUnit.km2);
       double areaRads2 = h3.cellArea(cell, AreaUnit.rads2);
 
-      assertEquals("cell area should match expectation", areasKm2[res], areaAddressKm2, EPSILON);
-      assertEquals("rads2 cell area should agree", areaAddressRads2, areaRads2, EPSILON);
-      assertEquals("km2 cell area should agree", areaAddressKm2, areaKm2, EPSILON);
-      assertEquals("m2 cell area should agree", areaAddressM2, areaM2, EPSILON);
-      assertTrue("m2 area greater than km2 area", areaM2 > areaKm2);
-      assertTrue("km2 area greater than rads2 area", areaKm2 > areaRads2);
+      assertEquals(areasKm2[res], areaAddressKm2, EPSILON, "cell area should match expectation");
+      assertEquals(areaAddressRads2, areaRads2, EPSILON, "rads2 cell area should agree");
+      assertEquals(areaAddressKm2, areaKm2, EPSILON, "km2 cell area should agree");
+      assertEquals(areaAddressM2, areaM2, EPSILON, "m2 cell area should agree");
+      assertTrue(areaM2 > areaKm2, "m2 area greater than km2 area");
+      assertTrue(areaKm2 > areaRads2, "km2 area greater than rads2 area");
     }
   }
 
   @Test
-  public void testCellAreaInvalid() {
+  void cellAreaInvalid() {
     // Passing in a zero should not cause a crash
     h3.cellArea(0, AreaUnit.rads2);
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testCellAreaInvalidUnit() {
+  @Test
+  void cellAreaInvalidUnit() {
     long cell = h3.geoToH3(0, 0, 0);
-    h3.cellArea(cell, null);
+    assertThrows(IllegalArgumentException.class, () -> h3.cellArea(cell, null));
   }
 
   @Test
-  public void testExactEdgeLength() {
+  void exactEdgeLength() {
     for (int res = 0; res <= 15; res++) {
       long cell = h3.geoToH3(0, 0, res);
 
@@ -171,36 +172,39 @@ public class TestMiscellaneous extends BaseTestH3CoreV3 {
         // Only asserts some properties of the functions that the edge lengths
         // should have certain relationships to each other, test isn't specific
         // to a cell's actual values.
-        assertTrue("edge length should match expectation", areaAddressRads > 0);
-        assertEquals("rads edge length should agree", areaAddressRads, areaRads, EPSILON);
-        assertEquals("km edge length should agree", areaAddressKm, areaKm, EPSILON);
-        assertEquals("m edge length should agree", areaAddressM, areaM, EPSILON);
-        assertTrue("m length greater than km length", areaM > areaKm);
-        assertTrue("km length greater than rads length", areaKm > areaRads);
+        assertTrue(areaAddressRads > 0, "edge length should match expectation");
+        assertEquals(areaAddressRads, areaRads, EPSILON, "rads edge length should agree");
+        assertEquals(areaAddressKm, areaKm, EPSILON, "km edge length should agree");
+        assertEquals(areaAddressM, areaM, EPSILON, "m edge length should agree");
+        assertTrue(areaM > areaKm, "m length greater than km length");
+        assertTrue(areaKm > areaRads, "km length greater than rads length");
       }
     }
   }
 
-  @Test(expected = H3Exception.class)
-  public void testExactEdgeLengthInvalid() {
-    // Passing in a non-edge should not cause a crash
-    h3.exactEdgeLength(h3.geoToH3(0, 0, 0), LengthUnit.km);
-  }
-
-  @Test(expected = H3Exception.class)
-  public void testExactEdgeLengthInvalidEdge() {
-    h3.exactEdgeLength(0, LengthUnit.rads);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testExactEdgeLengthInvalidUnit() {
-    long cell = h3.geoToH3(0, 0, 0);
-    long edge = h3.getH3UnidirectionalEdgesFromHexagon(cell).get(0);
-    h3.exactEdgeLength(edge, null);
+  @Test
+  void exactEdgeLengthInvalid() {
+    assertThrows(
+        H3Exception.class,
+        () ->
+            // Passing in a non-edge should not cause a crash
+            h3.exactEdgeLength(h3.geoToH3(0, 0, 0), LengthUnit.km));
   }
 
   @Test
-  public void testPointDist() {
+  void exactEdgeLengthInvalidEdge() {
+    assertThrows(H3Exception.class, () -> h3.exactEdgeLength(0, LengthUnit.rads));
+  }
+
+  @Test
+  void exactEdgeLengthInvalidUnit() {
+    long cell = h3.geoToH3(0, 0, 0);
+    long edge = h3.getH3UnidirectionalEdgesFromHexagon(cell).get(0);
+    assertThrows(IllegalArgumentException.class, () -> h3.exactEdgeLength(edge, null));
+  }
+
+  @Test
+  void pointDist() {
     LatLng[] testA = {new LatLng(10, 10), new LatLng(0, 0), new LatLng(23, 23)};
     LatLng[] testB = {new LatLng(10, -10), new LatLng(-10, 0), new LatLng(23, 23)};
     double[] testDistanceDegrees = {20, 10, 0};
@@ -215,84 +219,84 @@ public class TestMiscellaneous extends BaseTestH3CoreV3 {
       double distM = h3.pointDist(a, b, LengthUnit.m);
 
       // TODO: Epsilon is unusually large in the core H3 tests
-      assertEquals("radians distance is as expected", expectedRads, distRads, EPSILON * 10000);
+      assertEquals(expectedRads, distRads, EPSILON * 10000, "radians distance is as expected");
       if (expectedRads == 0) {
-        assertEquals("m distance is zero", 0, distM, EPSILON);
-        assertEquals("km distance is zero", 0, distKm, EPSILON);
+        assertEquals(0, distM, EPSILON, "m distance is zero");
+        assertEquals(0, distKm, EPSILON, "km distance is zero");
       } else {
-        assertTrue("m distance greater than km distance", distM > distKm);
-        assertTrue("km distance greater than rads distance", distKm > distRads);
+        assertTrue(distM > distKm, "m distance greater than km distance");
+        assertTrue(distKm > distRads, "km distance greater than rads distance");
       }
     }
   }
 
   @Test
-  public void testPointDistNaN() {
+  void pointDistNaN() {
     LatLng zero = new LatLng(0, 0);
     LatLng nan = new LatLng(Double.NaN, Double.NaN);
     double dist1 = h3.pointDist(nan, zero, LengthUnit.rads);
     double dist2 = h3.pointDist(zero, nan, LengthUnit.km);
     double dist3 = h3.pointDist(nan, nan, LengthUnit.m);
-    assertTrue("nan distance results in nan", Double.isNaN(dist1));
-    assertTrue("nan distance results in nan", Double.isNaN(dist2));
-    assertTrue("nan distance results in nan", Double.isNaN(dist3));
+    assertTrue(Double.isNaN(dist1), "nan distance results in nan");
+    assertTrue(Double.isNaN(dist2), "nan distance results in nan");
+    assertTrue(Double.isNaN(dist3), "nan distance results in nan");
   }
 
   @Test
-  public void testPointDistPositiveInfinity() {
+  void pointDistPositiveInfinity() {
     LatLng posInf = new LatLng(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
     LatLng zero = new LatLng(0, 0);
     double dist = h3.pointDist(posInf, zero, LengthUnit.m);
-    assertTrue("+Infinity distance results in NaN", Double.isNaN(dist));
+    assertTrue(Double.isNaN(dist), "+Infinity distance results in NaN");
   }
 
   @Test
-  public void testPointDistNegativeInfinity() {
+  void pointDistNegativeInfinity() {
     LatLng negInf = new LatLng(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY);
     LatLng zero = new LatLng(0, 0);
     double dist = h3.pointDist(negInf, zero, LengthUnit.m);
-    assertTrue("-Infinity distance results in NaN", Double.isNaN(dist));
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testPointDistInvalid() {
-    LatLng a = new LatLng(0, 0);
-    LatLng b = new LatLng(0, 0);
-    h3.pointDist(a, b, null);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testGetPentagonIndexesNegativeRes() {
-    h3.getPentagonIndexesAddresses(-1);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testGetPentagonIndexesOutOfRangeRes() {
-    h3.getPentagonIndexesAddresses(20);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testConstantsInvalid() {
-    h3.hexArea(-1, AreaUnit.km2);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testConstantsInvalidUnit() {
-    h3.hexArea(-1, AreaUnit.rads2);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testConstantsInvalid2() {
-    h3.hexArea(0, null);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testConstantsInvalid3() {
-    h3.edgeLength(0, null);
+    assertTrue(Double.isNaN(dist), "-Infinity distance results in NaN");
   }
 
   @Test
-  public void testStringToH3() {
+  void pointDistInvalid() {
+    LatLng a = new LatLng(0, 0);
+    LatLng b = new LatLng(0, 0);
+    assertThrows(IllegalArgumentException.class, () -> h3.pointDist(a, b, null));
+  }
+
+  @Test
+  void getPentagonIndexesNegativeRes() {
+    assertThrows(IllegalArgumentException.class, () -> h3.getPentagonIndexesAddresses(-1));
+  }
+
+  @Test
+  void getPentagonIndexesOutOfRangeRes() {
+    assertThrows(IllegalArgumentException.class, () -> h3.getPentagonIndexesAddresses(20));
+  }
+
+  @Test
+  void constantsInvalid() {
+    assertThrows(IllegalArgumentException.class, () -> h3.hexArea(-1, AreaUnit.km2));
+  }
+
+  @Test
+  void constantsInvalidUnit() {
+    assertThrows(IllegalArgumentException.class, () -> h3.hexArea(-1, AreaUnit.rads2));
+  }
+
+  @Test
+  void constantsInvalid2() {
+    assertThrows(IllegalArgumentException.class, () -> h3.hexArea(0, null));
+  }
+
+  @Test
+  void constantsInvalid3() {
+    assertThrows(IllegalArgumentException.class, () -> h3.edgeLength(0, null));
+  }
+
+  @Test
+  void stringToH3() {
     assertEquals("ffffffffffffffff", h3.h3ToString(0xffffffffffffffffL));
     assertEquals(0xffffffffffffffffL, h3.stringToH3("ffffffffffffffff"));
   }

--- a/src/test/java/com/uber/h3core/v3/TestRegion.java
+++ b/src/test/java/com/uber/h3core/v3/TestRegion.java
@@ -15,20 +15,20 @@
  */
 package com.uber.h3core.v3;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.uber.h3core.util.LatLng;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for region (polyfill, h3SetToMultiPolygon) functions. */
-public class TestRegion extends BaseTestH3CoreV3 {
+class TestRegion extends BaseTestH3CoreV3 {
   @Test
-  public void testPolyfill() {
+  void polyfill() {
     List<Long> hexagons =
         h3.polyfill(
             ImmutableList.of(
@@ -45,7 +45,7 @@ public class TestRegion extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testPolyfillAddresses() {
+  void polyfillAddresses() {
     List<String> hexagons =
         h3.polyfillAddress(
             ImmutableList.<LatLng>of(
@@ -62,7 +62,7 @@ public class TestRegion extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testPolyfillWithHole() {
+  void polyfillWithHole() {
     List<Long> hexagons =
         h3.polyfill(
             ImmutableList.<LatLng>of(
@@ -83,7 +83,7 @@ public class TestRegion extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testPolyfillWithTwoHoles() {
+  void polyfillWithTwoHoles() {
     List<Long> hexagons =
         h3.polyfill(
             ImmutableList.<LatLng>of(
@@ -108,7 +108,7 @@ public class TestRegion extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testPolyfillKnownHoles() {
+  void polyfillKnownHoles() {
     List<Long> inputHexagons = h3.kRing(0x85283083fffffffL, 2);
     inputHexagons.remove(0x8528308ffffffffL);
     inputHexagons.remove(0x85283097fffffffL);
@@ -124,12 +124,12 @@ public class TestRegion extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testH3SetToMultiPolygonEmpty() {
+  void h3SetToMultiPolygonEmpty() {
     assertEquals(0, h3.h3SetToMultiPolygon(new ArrayList<Long>(), false).size());
   }
 
   @Test
-  public void testH3SetToMultiPolygonSingle() {
+  void h3SetToMultiPolygonSingle() {
     long testIndex = 0x89283082837ffffL;
 
     List<LatLng> actualBounds = h3.h3ToGeoBoundary(testIndex);
@@ -155,7 +155,7 @@ public class TestRegion extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testH3SetToMultiPolygonSingleNonGeoJson() {
+  void h3SetToMultiPolygonSingleNonGeoJson() {
     long testIndex = 0x89283082837ffffL;
 
     List<LatLng> actualBounds = h3.h3ToGeoBoundary(testIndex);
@@ -181,7 +181,7 @@ public class TestRegion extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testH3SetToMultiPolygonContiguous2() {
+  void h3SetToMultiPolygonContiguous2() {
     long testIndex = 0x89283082837ffffL;
     long testIndex2 = 0x89283082833ffffL;
 
@@ -219,7 +219,7 @@ public class TestRegion extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testH3SetToMultiPolygonNonContiguous2() {
+  void h3SetToMultiPolygonNonContiguous2() {
     long testIndex = 0x89283082837ffffL;
     long testIndex2 = 0x8928308280fffffL;
 
@@ -234,7 +234,7 @@ public class TestRegion extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testH3SetToMultiPolygonHole() {
+  void h3SetToMultiPolygonHole() {
     // Six hexagons in a ring around a hole
     List<List<List<LatLng>>> multiBounds =
         h3.h3AddressSetToMultiPolygon(
@@ -254,7 +254,7 @@ public class TestRegion extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testH3SetToMultiPolygonLarge() {
+  void h3SetToMultiPolygonLarge() {
     int numHexes = 20000;
 
     List<String> addresses = new ArrayList<>(numHexes);

--- a/src/test/java/com/uber/h3core/v3/TestTraversal.java
+++ b/src/test/java/com/uber/h3core/v3/TestTraversal.java
@@ -15,18 +15,19 @@
  */
 package com.uber.h3core.v3;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.uber.h3core.exceptions.H3Exception;
 import com.uber.h3core.util.CoordIJ;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for grid traversal functions (k-ring, distance and line, and local IJ coordinates). */
-public class TestTraversal extends BaseTestH3CoreV3 {
+class TestTraversal extends BaseTestH3CoreV3 {
   @Test
-  public void testKring() {
+  void kring() {
     List<String> hexagons = h3.kRing("8928308280fffff", 1);
 
     assertEquals(1 + 6, hexagons.size());
@@ -41,7 +42,7 @@ public class TestTraversal extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testKring2() {
+  void kring2() {
     List<String> hexagons = h3.kRing("8928308280fffff", 2);
 
     assertEquals(1 + 6 + 12, hexagons.size());
@@ -68,7 +69,7 @@ public class TestTraversal extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testKrings() {
+  void krings() {
     String origin = "8928308280fffff";
     List<List<String>> hexagons = h3.kRings(origin, 2);
     assertEquals(h3.kRing(origin, 0), hexagons.get(0));
@@ -78,7 +79,7 @@ public class TestTraversal extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testKringLarge() {
+  void kringLarge() {
     int k = 50;
     List<String> hexagons = h3.kRing("8928308280fffff", k);
 
@@ -91,7 +92,7 @@ public class TestTraversal extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testKringPentagon() {
+  void kringPentagon() {
     List<String> hexagons = h3.kRing("821c07fffffffff", 1);
 
     assertEquals(1 + 5, hexagons.size());
@@ -105,7 +106,7 @@ public class TestTraversal extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testHexRange() {
+  void hexRange() {
     List<List<String>> hexagons = h3.hexRange("8928308280fffff", 1);
 
     assertEquals(2, hexagons.size());
@@ -122,7 +123,7 @@ public class TestTraversal extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testHexRangeLong() {
+  void hexRangeLong() {
     List<List<Long>> hexagons = h3.hexRange(0x8928308280fffffL, 1);
 
     assertEquals(2, hexagons.size());
@@ -139,7 +140,7 @@ public class TestTraversal extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testKRingDistances() {
+  void kRingDistances() {
     List<List<String>> hexagons = h3.kRingDistances("8928308280fffff", 1);
 
     assertEquals(2, hexagons.size());
@@ -156,7 +157,7 @@ public class TestTraversal extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testKRingDistancesLong() {
+  void kRingDistancesLong() {
     List<List<Long>> hexagons = h3.kRingDistances(0x8928308280fffffL, 1);
 
     assertEquals(2, hexagons.size());
@@ -173,7 +174,7 @@ public class TestTraversal extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testHexRange2() {
+  void hexRange2() {
     List<List<String>> hexagons = h3.kRingDistances("8928308280fffff", 2);
 
     assertEquals(3, hexagons.size());
@@ -203,18 +204,18 @@ public class TestTraversal extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testKRingDistancesPentagon() {
+  void kRingDistancesPentagon() {
     h3.kRingDistances("821c07fffffffff", 1);
     // No exception should happen
   }
 
-  @Test(expected = H3Exception.class)
-  public void testHexRangePentagon() {
-    h3.hexRange("821c07fffffffff", 1);
+  @Test
+  void hexRangePentagon() {
+    assertThrows(H3Exception.class, () -> h3.hexRange("821c07fffffffff", 1));
   }
 
   @Test
-  public void testHexRing() {
+  void hexRing() {
     List<String> hexagons = h3.hexRing("8928308280fffff", 1);
 
     assertEquals(6, hexagons.size());
@@ -228,7 +229,7 @@ public class TestTraversal extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testHexRingLong() {
+  void hexRingLong() {
     List<Long> hexagons = h3.hexRing(0x8928308280fffffL, 1);
 
     assertEquals(6, hexagons.size());
@@ -242,7 +243,7 @@ public class TestTraversal extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testHexRing2() {
+  void hexRing2() {
     List<String> hexagons = h3.hexRing("8928308280fffff", 2);
 
     assertEquals(12, hexagons.size());
@@ -262,7 +263,7 @@ public class TestTraversal extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testHexRingLarge() {
+  void hexRingLarge() {
     int k = 50;
     List<String> hexagons = h3.hexRing("8928308280fffff", k);
 
@@ -271,18 +272,18 @@ public class TestTraversal extends BaseTestH3CoreV3 {
     assertEquals(expectedCount, hexagons.size());
   }
 
-  @Test(expected = H3Exception.class)
-  public void testHexRingPentagon() {
-    h3.hexRing("821c07fffffffff", 1);
-  }
-
-  @Test(expected = H3Exception.class)
-  public void testHexRingAroundPentagon() {
-    h3.hexRing("821c37fffffffff", 2);
+  @Test
+  void hexRingPentagon() {
+    assertThrows(H3Exception.class, () -> h3.hexRing("821c07fffffffff", 1));
   }
 
   @Test
-  public void testHexRingSingle() {
+  void hexRingAroundPentagon() {
+    assertThrows(H3Exception.class, () -> h3.hexRing("821c37fffffffff", 2));
+  }
+
+  @Test
+  void hexRingSingle() {
     String origin = "8928308280fffff";
     List<String> hexagons = h3.hexRing(origin, 0);
 
@@ -290,30 +291,39 @@ public class TestTraversal extends BaseTestH3CoreV3 {
     assertEquals("8928308280fffff", hexagons.get(0));
   }
 
-  @Test(expected = H3Exception.class)
-  public void testH3DistanceFailedDistance() {
-    // This fails because of a limitation in the H3 core library.
-    // It cannot find distances when spanning more than one base cell.
-    // Expected correct result is 2.
-    h3.h3Distance("8029fffffffffff", "8079fffffffffff");
-  }
-
-  @Test(expected = H3Exception.class)
-  public void testH3DistanceFailedResolution() {
-    // Cannot find distances when the indexes are not comparable (different resolutions)
-    h3.h3Distance("81283ffffffffff", "8029fffffffffff");
-  }
-
-  @Test(expected = H3Exception.class)
-  public void testH3DistanceFailedPentagonDistortion() {
-    // This fails because of a limitation in the H3 core library.
-    // It cannot find distances from opposite sides of a pentagon.
-    // Expected correct result is 9.
-    h3.h3Distance("821c37fffffffff", "822837fffffffff");
+  @Test
+  void h3DistanceFailedDistance() {
+    assertThrows(
+        H3Exception.class,
+        () ->
+            // This fails because of a limitation in the H3 core library.
+            // It cannot find distances when spanning more than one base cell.
+            // Expected correct result is 2.
+            h3.h3Distance("8029fffffffffff", "8079fffffffffff"));
   }
 
   @Test
-  public void testH3Distance() {
+  void h3DistanceFailedResolution() {
+    assertThrows(
+        H3Exception.class,
+        () ->
+            // Cannot find distances when the indexes are not comparable (different resolutions)
+            h3.h3Distance("81283ffffffffff", "8029fffffffffff"));
+  }
+
+  @Test
+  void h3DistanceFailedPentagonDistortion() {
+    assertThrows(
+        H3Exception.class,
+        () ->
+            // This fails because of a limitation in the H3 core library.
+            // It cannot find distances from opposite sides of a pentagon.
+            // Expected correct result is 9.
+            h3.h3Distance("821c37fffffffff", "822837fffffffff"));
+  }
+
+  @Test
+  void h3Distance() {
     // Resolution 0 to some neighbors
     assertEquals(0, h3.h3Distance(0x8029fffffffffffL, 0x8029fffffffffffL));
     assertEquals(1, h3.h3Distance("8029fffffffffff", "801dfffffffffff"));
@@ -333,29 +343,36 @@ public class TestTraversal extends BaseTestH3CoreV3 {
     assertEquals(5, h3.h3Distance(0x85283083fffffffL, 0x85283447fffffffL));
   }
 
-  @Test(expected = H3Exception.class)
-  public void testDistanceAcrossPentagon() {
-    // Opposite sides of a pentagon.
-    h3.h3Distance("81283ffffffffff", "811dbffffffffff");
-  }
-
-  @Test(expected = H3Exception.class)
-  public void testCellToLocalIjNoncomparable() {
-    h3.experimentalH3ToLocalIj(0x832830fffffffffL, 0x822837fffffffffL);
-  }
-
-  @Test(expected = H3Exception.class)
-  public void testCellToLocalIjTooFar() {
-    h3.experimentalH3ToLocalIj("822a17fffffffff", "822837fffffffff");
-  }
-
-  @Test(expected = H3Exception.class)
-  public void testCellToLocalIjPentagonDistortion() {
-    h3.experimentalH3ToLocalIj("81283ffffffffff", "811cbffffffffff");
+  @Test
+  void distanceAcrossPentagon() {
+    assertThrows(
+        H3Exception.class,
+        () ->
+            // Opposite sides of a pentagon.
+            h3.h3Distance("81283ffffffffff", "811dbffffffffff"));
   }
 
   @Test
-  public void testCellToLocalIjPentagon() {
+  void cellToLocalIjNoncomparable() {
+    assertThrows(
+        H3Exception.class,
+        () -> h3.experimentalH3ToLocalIj(0x832830fffffffffL, 0x822837fffffffffL));
+  }
+
+  @Test
+  void cellToLocalIjTooFar() {
+    assertThrows(
+        H3Exception.class, () -> h3.experimentalH3ToLocalIj("822a17fffffffff", "822837fffffffff"));
+  }
+
+  @Test
+  void cellToLocalIjPentagonDistortion() {
+    assertThrows(
+        H3Exception.class, () -> h3.experimentalH3ToLocalIj("81283ffffffffff", "811cbffffffffff"));
+  }
+
+  @Test
+  void cellToLocalIjPentagon() {
     final String origin = "811c3ffffffffff";
     assertEquals(new CoordIJ(0, 0), h3.experimentalH3ToLocalIj(origin, origin));
     assertEquals(new CoordIJ(1, 0), h3.experimentalH3ToLocalIj(origin, "811d3ffffffffff"));
@@ -363,7 +380,7 @@ public class TestTraversal extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testCellToLocalIjHexagons() {
+  void cellToLocalIjHexagons() {
     final String origin = "8828308281fffff";
     assertEquals(new CoordIJ(392, 336), h3.experimentalH3ToLocalIj(origin, origin));
     assertEquals(new CoordIJ(387, 336), h3.experimentalH3ToLocalIj(origin, "88283080c3fffff"));
@@ -371,7 +388,7 @@ public class TestTraversal extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testLocalIjToCellPentagon() {
+  void localIjToCellPentagon() {
     final String origin = "811c3ffffffffff";
     assertEquals(origin, h3.experimentalLocalIjToH3(origin, new CoordIJ(0, 0)));
     assertEquals("811d3ffffffffff", h3.experimentalLocalIjToH3(origin, new CoordIJ(1, 0)));
@@ -379,7 +396,7 @@ public class TestTraversal extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testCellToLocalIjHexagonsLong() {
+  void cellToLocalIjHexagonsLong() {
     final long origin = 0x8828308281fffffL;
     assertEquals(new CoordIJ(392, 336), h3.experimentalH3ToLocalIj(origin, origin));
     assertEquals(new CoordIJ(387, 336), h3.experimentalH3ToLocalIj(origin, 0x88283080c3fffffL));
@@ -387,25 +404,27 @@ public class TestTraversal extends BaseTestH3CoreV3 {
   }
 
   @Test
-  public void testLocalIjToCellPentagonLong() {
+  void localIjToCellPentagonLong() {
     final long origin = 0x811c3ffffffffffL;
     assertEquals(origin, h3.experimentalLocalIjToH3(origin, new CoordIJ(0, 0)));
     assertEquals(0x811d3ffffffffffL, h3.experimentalLocalIjToH3(origin, new CoordIJ(1, 0)));
     assertEquals(0x811cfffffffffffL, h3.experimentalLocalIjToH3(origin, new CoordIJ(-1, 0)));
   }
 
-  @Test(expected = H3Exception.class)
-  public void testLocalIjToCellTooFar() {
-    h3.experimentalLocalIjToH3("8049fffffffffff", new CoordIJ(2, 0));
-  }
-
-  @Test(expected = H3Exception.class)
-  public void testLocalIjToCellTooFarLong() {
-    h3.experimentalLocalIjToH3(0x8049fffffffffffL, new CoordIJ(2, 0));
+  @Test
+  void localIjToCellTooFar() {
+    assertThrows(
+        H3Exception.class, () -> h3.experimentalLocalIjToH3("8049fffffffffff", new CoordIJ(2, 0)));
   }
 
   @Test
-  public void testH3Line() {
+  void localIjToCellTooFarLong() {
+    assertThrows(
+        H3Exception.class, () -> h3.experimentalLocalIjToH3(0x8049fffffffffffL, new CoordIJ(2, 0)));
+  }
+
+  @Test
+  void h3Line() {
     for (int res = 0; res < 12; res++) {
       String origin = h3.geoToH3Address(37.5, -122, res);
       String destination = h3.geoToH3Address(25, -120, res);
@@ -414,21 +433,21 @@ public class TestTraversal extends BaseTestH3CoreV3 {
       long distance = h3.h3Distance(origin, destination);
 
       // Need to add 1 to account for the origin as well
-      assertEquals("Distance matches expected", distance + 1, line.size());
+      assertEquals(distance + 1, line.size(), "Distance matches expected");
 
       for (int i = 1; i < line.size(); i++) {
         assertTrue(
-            "Every index in the line is a neighbor of the previous",
-            h3.h3IndexesAreNeighbors(line.get(i - 1), line.get(i)));
+            h3.h3IndexesAreNeighbors(line.get(i - 1), line.get(i)),
+            "Every index in the line is a neighbor of the previous");
       }
 
-      assertTrue("Line contains start", line.contains(origin));
-      assertTrue("Line contains destination", line.contains(destination));
+      assertTrue(line.contains(origin), "Line contains start");
+      assertTrue(line.contains(destination), "Line contains destination");
     }
   }
 
   @Test
-  public void testH3LineLong() {
+  void h3LineLong() {
     for (int res = 0; res < 12; res++) {
       long origin = h3.geoToH3(37.5, -122, res);
       long destination = h3.geoToH3(25, -120, res);
@@ -437,24 +456,23 @@ public class TestTraversal extends BaseTestH3CoreV3 {
       long distance = h3.h3Distance(origin, destination);
 
       // Need to add 1 to account for the origin as well
-      assertEquals("Distance matches expected", distance + 1, line.size());
+      assertEquals(distance + 1, line.size(), "Distance matches expected");
 
       for (int i = 1; i < line.size(); i++) {
         assertTrue(
-            "Every index in the line is a neighbor of the previous",
-            h3.h3IndexesAreNeighbors(line.get(i - 1), line.get(i)));
+            h3.h3IndexesAreNeighbors(line.get(i - 1), line.get(i)),
+            "Every index in the line is a neighbor of the previous");
       }
 
-      assertTrue("Line contains start", line.contains(origin));
-      assertTrue("Line contains destination", line.contains(destination));
+      assertTrue(line.contains(origin), "Line contains start");
+      assertTrue(line.contains(destination), "Line contains destination");
     }
   }
 
-  @Test(expected = H3Exception.class)
-  public void testH3LineFailed() {
+  @Test
+  void h3LineFailed() {
     long origin = h3.geoToH3(37.5, -122, 9);
     long destination = h3.geoToH3(37.5, -122, 10);
-
-    h3.h3Line(origin, destination);
+    assertThrows(H3Exception.class, () -> h3.h3Line(origin, destination));
   }
 }


### PR DESCRIPTION
Adds native image test to the test matrix.
In order to do native image testing had to bump JUnit 4 to 5.
Mainly run the openrewrite recipe:
```
mvn org.openrewrite.maven:rewrite-maven-plugin:5.42.2:run \
 -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-testing-frameworks:2.20.1 \
 -Drewrite.activeRecipes=org.openrewrite.java.testing.junit5.JUnit4to5Migration,org.openrewrite.java.testing.junit5.JUnit5BestPractices
```
And later added a `@DisabledInNativeImage` for `TestBindingCompleteness` since we don't need to run this is native image and there this one fails because `H3Core.class` is not registered for reflection and also doesn't need to be for the project to work correctly.

If something is wrong in native image, resources for example we will get a failure like:
![image](https://github.com/user-attachments/assets/35d643ac-700d-4636-ba43-9a2cd6d2455b)

Or if something is wrong with the jni config we will get a seg fault like:
<img width="812" alt="image" src="https://github.com/user-attachments/assets/b4dbecc5-775f-4098-9939-4a45e0418d7f">

If you want to test it locally you need to have GraalVM installed (SDKMan is a good tool to manage installed SDKs) and run `mvn -Dnative verify` that will build and use the generated jar to run the the tests against. 
You should get a message stating:
<img width="663" alt="image" src="https://github.com/user-attachments/assets/d4c6f372-36c3-4a15-94d2-dac1775373a1">
