### PR TITLE
polygonToCellsExperimental reorder flag, res arguments

### DIFF
--- a/src/main/java/com/uber/h3core/H3Core.java
+++ b/src/main/java/com/uber/h3core/H3Core.java
@@ -525,8 +525,8 @@ public class H3Core {
    * @param res Resolution of the desired indexes
    */
   public List<String> polygonToCellAddressesExperimental(
-      List<LatLng> points, List<List<LatLng>> holes, PolygonToCellsFlags flags, int res) {
-    return h3ToStringList(polygonToCellsExperimental(points, holes, flags, res));
+      List<LatLng> points, List<List<LatLng>> holes, int res, PolygonToCellsFlags flags) {
+    return h3ToStringList(polygonToCellsExperimental(points, holes, res, flags));
   }
 
   /**
@@ -538,7 +538,7 @@ public class H3Core {
    * @throws IllegalArgumentException Invalid resolution
    */
   public List<Long> polygonToCellsExperimental(
-      List<LatLng> points, List<List<LatLng>> holes, PolygonToCellsFlags flags, int res) {
+      List<LatLng> points, List<List<LatLng>> holes, int res, PolygonToCellsFlags flags) {
     checkResolution(res);
 
     // pack the data for use by the polyfill JNI call

--- a/src/test/java/com/uber/h3core/TestRegion.java
+++ b/src/test/java/com/uber/h3core/TestRegion.java
@@ -41,8 +41,8 @@ class TestRegion extends BaseTestH3Core {
                 new LatLng(37.7835871999971715, -122.5247187000021967),
                 new LatLng(37.8151571999998453, -122.4798767000009008)),
             null,
-            PolygonToCellsFlags.containment_center,
-            9);
+            9,
+            PolygonToCellsFlags.containment_center);
 
     assertTrue(hexagons.size() > 1000);
   }
@@ -59,8 +59,8 @@ class TestRegion extends BaseTestH3Core {
                 new LatLng(37.7835871999971715, -122.5247187000021967),
                 new LatLng(37.8151571999998453, -122.4798767000009008)),
             null,
-            PolygonToCellsFlags.containment_full,
-            9);
+            9,
+            PolygonToCellsFlags.containment_full);
 
     assertTrue(hexagons.size() > 1000);
   }
@@ -77,8 +77,8 @@ class TestRegion extends BaseTestH3Core {
                 new LatLng(37.7835871999971715, -122.5247187000021967),
                 new LatLng(37.8151571999998453, -122.4798767000009008)),
             null,
-            PolygonToCellsFlags.containment_overlapping,
-            9);
+            9,
+            PolygonToCellsFlags.containment_overlapping);
 
     assertTrue(hexagons.size() > 1000);
   }
@@ -95,8 +95,8 @@ class TestRegion extends BaseTestH3Core {
                 new LatLng(37.7835871999971715, -122.5247187000021967),
                 new LatLng(37.8151571999998453, -122.4798767000009008)),
             null,
-            PolygonToCellsFlags.containment_overlapping_bbox,
-            9);
+            9,
+            PolygonToCellsFlags.containment_overlapping_bbox);
 
     assertTrue(hexagons.size() > 1000);
   }
@@ -113,8 +113,8 @@ class TestRegion extends BaseTestH3Core {
                 new LatLng(37.7835871999971715, -122.5247187000021967),
                 new LatLng(37.8151571999998453, -122.4798767000009008)),
             null,
-            PolygonToCellsFlags.containment_center,
-            9);
+            9,
+            PolygonToCellsFlags.containment_center);
 
     assertTrue(hexagons.size() > 1000);
   }


### PR DESCRIPTION
See also https://github.com/isaacbrodsky/h3-duckdb/issues/145
The correct order used in C, Python, and JavaScript is https://h3geo.org/docs/api/regions#polygontocellsexperimental