### PR TITLE
fix release version for v4.3.0

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -2,7 +2,7 @@
 
 The H3-Java library is published to Maven Central via OSSRH.
 
-Before releasing, make sure the version of the project is in the form `1.2.3-SNAPSHOT` where `1.2.3` is the version you wish to release. The release is triggered via GitHub Actions, when a tag of the form `v1.2.3` is pushed. (Workflow dispatch can be used but is not tested.)
+Before releasing, make sure the version of the project is in the form `1.2.3` (no `-SNAPSHOT`) where `1.2.3` is the version you wish to release. The release is triggered via GitHub Actions, when a tag of the form `v1.2.3` is pushed. (Workflow dispatch can be used but is not tested.)
 
 ## Old instructions for manual releasing
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,5 +5,5 @@
 org.gradle.configuration-cache=false
 
 # No spaces on the following line, needed by release.yml:
-version=4.3.0-SNAPSHOT
+version=4.3.0
 


### PR DESCRIPTION
#160 

Releasing using the tag and this properties file is an error as it attempts to upload a SNAPSHOT version (the -SNAPSHOT stripping is only if the workflow dispatch is used.)

The relevant error is:
```
   > Could not PUT 'https://s01.oss.sonatype.org/content/repositories/snapshots/com/uber/h3/4.3.0-SNAPSHOT/h3-4.3.0-20250626.120000-1.jar'. Received status code 401 from server: Content access is protected by token
```
https://github.com/uber/h3-java/actions/runs/15901027588/job/44844316941