### PR TITLE
Update build.gradle URLs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,7 +116,7 @@ jobs:
       matrix:
         # TODO: Docker on macos-latest running is not working
         # TODO: Windows pinned back
-        os: [macos-latest, windows-2019]
+        os: [macos-latest, windows-2022]
         java-distribution: [adopt]
         java-version: [8, 11, 17, 21, 22]
 

--- a/build.gradle
+++ b/build.gradle
@@ -184,9 +184,8 @@ nexusPublishing {
             // stagingProfileId.set(System.getenv("OSSRH_STAGING_PROFILE_ID"))
             username.set(System.getenv("OSSRH_USERNAME"))
             password.set(System.getenv("OSSRH_PASSWORD"))
-            // For newer Sonatype accounts (after Feb 2021) use "s01.oss.sonatype.org":
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
 }


### PR DESCRIPTION
I am not 100% sure about these URLs because it's not my token, but I understand ossrh is EOL and this is the replacement, so it seems like the next thing to do: https://central.sonatype.org/pages/ossrh-eol/#central-support