### PR TITLE
release followup: glibc, android 16kb, release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         java-distribution: [adopt]
         java-version: [11]
         dockcross-only:
@@ -122,7 +122,7 @@ jobs:
           if-no-files-found: error
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write # allow pushing commits/tags
 
@@ -211,14 +211,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Bump to next snapshot version
-        if: ${{ github.event_name != 'workflow_dispatch' }}
-        run: |
-          # Bump minor version (for example) and append -SNAPSHOT for continued development
-          NEXT_VERSION=$(echo $RELEASE_VERSION | awk -F. -v OFS="." '{$NF += 1; print $0}')  # increment last segment
-          NEXT_VERSION="$NEXT_VERSION-SNAPSHOT"
-          sed -i -E "s/$RELEASE_VERSION/$NEXT_VERSION/" gradle.properties || true
-          git config user.name "github-actions"
-          git config user.email "[email protected]"
-          git commit -am "chore: start next development cycle $NEXT_VERSION [skip ci]"
-          git push origin HEAD:master
+      # This doesn't work because we don't permit pushes directly to main.
+      # - name: Bump to next snapshot version
+      #   if: ${{ github.event_name != 'workflow_dispatch' }}
+      #   run: |
+      #     # Bump minor version (for example) and append -SNAPSHOT for continued development
+      #     NEXT_VERSION=$(echo $RELEASE_VERSION | awk -F. -v OFS="." '{$NF += 1; print $0}')  # increment last segment
+      #     NEXT_VERSION="$NEXT_VERSION-SNAPSHOT"
+      #     sed -i -E "s/$RELEASE_VERSION/$NEXT_VERSION/" gradle.properties || true
+      #     git config user.name "github-actions"
+      #     git config user.email "[email protected]"
+      #     git commit -am "chore: start next development cycle $NEXT_VERSION [skip ci]"
+      #     git push origin HEAD:master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,6 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Format check
-        if: ${{ matrix.java-version != 11 }}
         run: ./gradlew spotlessCheck
 
       - name: Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         java-distribution: [adopt]
         java-version: [11, 17, 21, 22]
         dockcross-only: ["android-arm", "android-arm64", "linux-arm64", "linux-armv5", "linux-armv7", "linux-s390x", "linux-ppc64le", "linux-x64", "linux-x86", "windows-static-x64", "windows-static-x86"]
@@ -45,9 +45,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      # - name: Format check
-      #   if: ${{ matrix.java-version != 8 }}
-      #   run: ./gradlew spotlessCheck
+      - name: Format check
+        if: ${{ matrix.java-version != 11 }}
+        run: ./gradlew spotlessCheck
 
       - name: Tests
         run: ./gradlew clean test -Ph3SystemPrune=true "-Ph3DockcrossOnly=${{ matrix.dockcross-only }}"
@@ -73,7 +73,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         java-distribution: [adopt]
         java-version: [21]
         dockcross-tag: ["latest"]
@@ -161,7 +161,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         java-distribution: [adopt]
         java-version: [21]
 
@@ -204,7 +204,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         java-distribution: [adopt]
         java-version: [11]
 
@@ -260,7 +260,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-22.04 ]
         java-distribution: [ graalvm ]
         java-version: [ 21 ]
 

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   deploy-website:
     name: Deploy website
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ The public API of this library consists of the public functions declared in
 file [H3Core.java](./src/main/java/com/uber/h3core/H3Core.java), and support
 for the Linux x64 and Darwin x64 platforms.
 
-## [4.3.0] - 2025-06-26
+## Unreleased Changes
+### Changed
+- Reverted Ubuntu build to 22.04 for older glibc compatibility.
+- Upgraded dockcross version for Android 16kb support.
+
+## [4.3.0] - 2025-08-21
 ### Added
 - `polygonToCellsExperimental` functions from H3 v4.2.0. (#163)
 - `gridRing` function from H3 v4.3.0. (#169)

--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,7 @@ plugins {
     id 'signing'
     id 'jacoco'
     // id 'com.github.spotbugs' version '5.2.1'
-    // TODO: Requires Java 11
-    // id 'com.diffplug.spotless' version '6.25.0'
+    id 'com.diffplug.spotless' version '7.2.1'
     id 'com.github.nbaztec.coveralls-jacoco' version '1.2.20'
     id 'com.vanniktech.maven.publish' version '0.34.0'
 }
@@ -52,7 +51,7 @@ ext {
     h3GitRemote = project.findProperty('h3GitRemote') ?: 'https://github.com/uber/h3.git'
     h3UseDocker = project.findProperty('h3UseDocker') ?: 'true'
     h3SystemPrune = project.findProperty('h3SystemPrune') ?: 'false'
-    h3DockcrossTag = project.findProperty('h3DockcrossTag') ?: '20240812-60fa1b0'
+    h3DockcrossTag = project.findProperty('h3DockcrossTag') ?: '20250818-0a27819'
     h3DockcrossOnly = project.findProperty('h3DockcrossOnly') ?: ''
     h3GithubArtifactsUse = project.findProperty('h3GithubArtifactsUse') ?: 'false'
     h3GithubArtifactsByRun = project.findProperty('h3GithubArtifactsByRun') ?: ''
@@ -91,11 +90,11 @@ test {
     // finalizedBy jacocoTestReport
 }
 
-// spotless {
-//     java {
-//         googleJavaFormat()
-//     }
-// }
+spotless {
+    java {
+        googleJavaFormat()
+    }
+}
 
 jacoco {
     toolVersion = '0.8.12'

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ ext {
     h3GitRemote = project.findProperty('h3GitRemote') ?: 'https://github.com/uber/h3.git'
     h3UseDocker = project.findProperty('h3UseDocker') ?: 'true'
     h3SystemPrune = project.findProperty('h3SystemPrune') ?: 'false'
-    h3DockcrossTag = project.findProperty('h3DockcrossTag') ?: '20250818-0a27819'
+    h3DockcrossTag = project.findProperty('h3DockcrossTag') ?: '20240812-60fa1b0'
     h3DockcrossOnly = project.findProperty('h3DockcrossOnly') ?: ''
     h3GithubArtifactsUse = project.findProperty('h3GithubArtifactsUse') ?: 'false'
     h3GithubArtifactsByRun = project.findProperty('h3GithubArtifactsByRun') ?: ''

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,5 +5,5 @@
 org.gradle.configuration-cache=false
 
 # No spaces on the following line, needed by release.yml:
-version=4.3.0
+version=4.3.1-SNAPSHOT
 

--- a/src/main/c/h3-java/CMakeLists.txt
+++ b/src/main/c/h3-java/CMakeLists.txt
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.20)
 
 set(CMAKE_C_STANDARD_REQUIRED 1)
 set(CMAKE_C_STANDARD 11)
@@ -66,6 +66,11 @@ set(H3_CORE_LIBRARY_PATH "/lib/libh3" CACHE STRING "Path to the built core libra
 mark_as_advanced(H3_CORE_LIBRARY_PATH)
 
 target_link_libraries(h3-java "${H3_BUILD_ROOT}/${H3_CORE_LIBRARY_PATH}${CMAKE_STATIC_LIBRARY_SUFFIX}")
+
+option(H3_JAVA_ANDROID "Whether to enable Android specific build flags")
+if(H3_JAVA_ANDROID)
+    target_link_options(h3-java PRIVATE "-Wl,-z,max-page-size=16384")
+endif()
 
 find_library(M_LIB m)
 if(M_LIB)

--- a/src/main/c/h3-java/build-h3-docker.sh
+++ b/src/main/c/h3-java/build-h3-docker.sh
@@ -15,10 +15,11 @@
 # limitations under the License.
 #
 
-# Arguments: [build-root] [upgrade-cmake]
-# build-root    - Location to build the library.
-# upgrade-cmake - Whether to download and install a new version of CMake
-# cmake-root    - Where to download and install the new version of CMake
+# Arguments: [build-root] [upgrade-cmake] [cmake-root] [cmake-additional]
+# build-root       - Location to build the library.
+# upgrade-cmake    - Whether to download and install a new version of CMake
+# cmake-root       - Where to download and install the new version of CMake
+# cmake-additional - Additional arguments to pass to CMake
 #
 # Builds H3 and H3-Java in the given directory. This is intended to be
 # called from build-h3.sh as part of the cross compilation process.
@@ -28,6 +29,7 @@ set -ex
 BUILD_ROOT=$1
 UPGRADE_CMAKE=$2
 CMAKE_ROOT=$3
+CMAKE_ADDITIONAL=$4
 
 # TODO: This may no longer be necessary
 if $UPGRADE_CMAKE; then
@@ -58,6 +60,7 @@ cmake -DBUILD_SHARED_LIBS=OFF \
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=lib \
+    $CMAKE_ADDITIONAL \
     ../../h3
 make h3
 H3_BUILD_ROOT="$(pwd)"
@@ -67,5 +70,6 @@ popd
 cmake -DBUILD_SHARED_LIBS=ON \
     "-DH3_BUILD_ROOT=$H3_BUILD_ROOT" \
     -DCMAKE_BUILD_TYPE=Release \
+    $CMAKE_ADDITIONAL \
     /work/src/main/c/h3-java
 make h3-java

--- a/src/main/c/h3-java/build-h3.sh
+++ b/src/main/c/h3-java/build-h3.sh
@@ -197,7 +197,7 @@ for image in $DOCKCROSS_IMAGES; do
     BUILD_ROOT=target/h3-java-build-$image
     mkdir -p $BUILD_ROOT
     # Handle dockcross images built for more than one host architecture
-    if [ $image -eq "linux-arm64" ]; then
+    if [ "$image" = "linux-arm64" ]; then
         CURRENT_DOCKCROSS_TAG="$DOCKCROSS_TAG-amd64"
     else
         CURRENT_DOCKCROSS_TAG="$DOCKCROSS_TAG"

--- a/src/main/c/h3-java/build-h3.sh
+++ b/src/main/c/h3-java/build-h3.sh
@@ -196,6 +196,12 @@ for image in $DOCKCROSS_IMAGES; do
     # Setup for using dockcross
     BUILD_ROOT=target/h3-java-build-$image
     mkdir -p $BUILD_ROOT
+    # Handle dockcross images built for more than one host architecture
+    if [ $image -eq "linux-arm64" ]; then
+        CURRENT_DOCKCROSS_TAG="$DOCKCROSS_TAG-amd64"
+    else
+        CURRENT_DOCKCROSS_TAG="$DOCKCROSS_TAG"
+    fi
     docker pull dockcross/$image:$DOCKCROSS_TAG
     docker run --rm dockcross/$image:$DOCKCROSS_TAG > $BUILD_ROOT/dockcross
     chmod +x $BUILD_ROOT/dockcross

--- a/src/main/c/h3-java/build-h3.sh
+++ b/src/main/c/h3-java/build-h3.sh
@@ -202,8 +202,8 @@ for image in $DOCKCROSS_IMAGES; do
     else
         CURRENT_DOCKCROSS_TAG="$DOCKCROSS_TAG"
     fi
-    docker pull dockcross/$image:$DOCKCROSS_TAG
-    docker run --rm dockcross/$image:$DOCKCROSS_TAG > $BUILD_ROOT/dockcross
+    docker pull dockcross/$image:$CURRENT_DOCKCROSS_TAG
+    docker run --rm dockcross/$image:$CURRENT_DOCKCROSS_TAG > $BUILD_ROOT/dockcross
     chmod +x $BUILD_ROOT/dockcross
 
     # Perform the actual build inside Docker

--- a/src/main/c/h3-java/build-h3.sh
+++ b/src/main/c/h3-java/build-h3.sh
@@ -196,18 +196,20 @@ for image in $DOCKCROSS_IMAGES; do
     # Setup for using dockcross
     BUILD_ROOT=target/h3-java-build-$image
     mkdir -p $BUILD_ROOT
-    # Handle dockcross images built for more than one host architecture
-    if [ "$image" = "linux-arm64" ]; then
-        CURRENT_DOCKCROSS_TAG="$DOCKCROSS_TAG-amd64"
-    else
-        CURRENT_DOCKCROSS_TAG="$DOCKCROSS_TAG"
-    fi
-    docker pull dockcross/$image:$CURRENT_DOCKCROSS_TAG
-    docker run --rm dockcross/$image:$CURRENT_DOCKCROSS_TAG > $BUILD_ROOT/dockcross
+    docker pull dockcross/$image:$DOCKCROSS_TAG
+    docker run --rm dockcross/$image:$DOCKCROSS_TAG > $BUILD_ROOT/dockcross
     chmod +x $BUILD_ROOT/dockcross
 
+    SPECIAL_ANDROID_FLAGS=""
+    if [ "$image" = "android-arm" ]; then
+        SPECIAL_ANDROID_FLAGS="-DH3_JAVA_ANDROID=ON"
+    fi
+    if [ "$image" = "android-arm64" ]; then
+        SPECIAL_ANDROID_FLAGS="-DH3_JAVA_ANDROID=ON"
+    fi
+
     # Perform the actual build inside Docker
-    $BUILD_ROOT/dockcross --args "-v $JAVA_HOME:/java" src/main/c/h3-java/build-h3-docker.sh "$BUILD_ROOT" "$UPGRADE_CMAKE" "$CMAKE_ROOT"
+    $BUILD_ROOT/dockcross --args "-v $JAVA_HOME:/java" src/main/c/h3-java/build-h3-docker.sh "$BUILD_ROOT" "$UPGRADE_CMAKE" "$CMAKE_ROOT" "$SPECIAL_ANDROID_FLAGS"
 
     # Copy the built artifact into the source tree so it can be included in the
     # built JAR.


### PR DESCRIPTION
May fix #180 but I think that is related to the dockcross version, not to the GH Actions runner.

Should fix #178 (This fixes a crash after the release completes in Github Actions. - I disabled automation of that step), #159 (edit: would appreciate testing of this). 