### PR TITLE
attempt to fix h3-java publishing for jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,7 @@ jacocoTestReport {
 
 jar {
     dependsOn buildH3
+    mustRunAfter buildH3Android
     from sourceSets.main.resources
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
@@ -255,6 +256,7 @@ mavenPublishing {
 
 sourcesJar {
     dependsOn buildH3
+    mustRunAfter buildH3Android
 }
 
 


### PR DESCRIPTION
https://github.com/uber/h3-java/actions/runs/18414099840/job/52474291675 H3-Java publish didn't run, I think because the last build step tries to build an aar and a jar at the same time. I will also test this in my repo as I am not 100% sure I can dry-run the publishing.