### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,11 @@ jobs:
           ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v5
         with:
           distribution: "${{ matrix.java-distribution }}"
           java-version: "${{ matrix.java-version }}"
@@ -52,7 +52,7 @@ jobs:
         with:
           gradle-version: wrapper
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: gradle-cache
         with:
           path: |
@@ -67,7 +67,7 @@ jobs:
         env:
           OCI_EXE: docker
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         name: Upload artifacts
         with:
           name: docker-built-shared-objects-${{ matrix.dockcross-only }}
@@ -88,11 +88,11 @@ jobs:
         java-version: [11]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v5
         with:
           distribution: "${{ matrix.java-distribution }}"
           java-version: "${{ matrix.java-version }}"
@@ -101,7 +101,7 @@ jobs:
         with:
           gradle-version: wrapper
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: gradle-cache
         with:
           path: |
@@ -114,7 +114,7 @@ jobs:
       - name: Tests
         run: ./gradlew clean test
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         name: Upload Mac OS Artifacts
         with:
           name: macos-built-shared-objects
@@ -132,10 +132,10 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "21"
@@ -167,14 +167,14 @@ jobs:
           git push origin HEAD:master --follow-tags
 
       - name: Download Docker binaries
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v7.0.0
         with:
           pattern: docker-built-shared-objects-*
           merge-multiple: true
           path: src/main/resources/
 
       - name: Download Mac binaries
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v7.0.0
         with:
           name: macos-built-shared-objects
           path: src/main/resources/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,11 +22,11 @@ jobs:
         dockcross-only: ["android-arm", "android-arm64", "linux-arm64", "linux-armv5", "linux-armv7", "linux-s390x", "linux-ppc64le", "linux-x64", "linux-x86", "windows-static-x64", "windows-static-x86"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v5
         with:
           distribution: "${{ matrix.java-distribution }}"
           java-version: "${{ matrix.java-version }}"
@@ -35,7 +35,7 @@ jobs:
         with:
           gradle-version: wrapper
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: gradle-cache
         with:
           path: |
@@ -56,7 +56,7 @@ jobs:
       - name: Format check for C
         run: git diff --exit-code
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         name: Upload artifacts
         if: ${{ matrix.java-version == 11 }}
         with:
@@ -79,11 +79,11 @@ jobs:
         dockcross-only: ["android-arm", "android-arm64", "linux-arm64", "linux-armv5", "linux-armv7", "linux-s390x", "linux-ppc64le", "linux-x64", "linux-x86", "windows-static-x64", "windows-static-x86"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: "${{ matrix.java-distribution }}"
           java-version: "${{ matrix.java-version }}"
@@ -92,7 +92,7 @@ jobs:
         with:
           gradle-version: wrapper
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: gradle-cache
         with:
           path: |
@@ -120,11 +120,11 @@ jobs:
         java-version: [11, 17, 21, 22]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v5
         with:
           distribution: "${{ matrix.java-distribution }}"
           java-version: "${{ matrix.java-version }}"
@@ -133,7 +133,7 @@ jobs:
         with:
           gradle-version: wrapper
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: gradle-cache
         with:
           path: |
@@ -146,7 +146,7 @@ jobs:
       - name: Tests
         run: ./gradlew clean test
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         name: Upload Mac OS Artifacts
         if: ${{ matrix.os == 'macos-latest' && matrix.java-version == 11 }}
         with:
@@ -165,11 +165,11 @@ jobs:
         java-version: [21]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v5
         with:
           distribution: "${{ matrix.java-distribution }}"
           java-version: "${{ matrix.java-version }}"
@@ -178,7 +178,7 @@ jobs:
         with:
           gradle-version: wrapper
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: gradle-cache
         with:
           path: |
@@ -208,11 +208,11 @@ jobs:
         java-version: [11]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v5
         with:
           distribution: "${{ matrix.java-distribution }}"
           java-version: "${{ matrix.java-version }}"
@@ -221,7 +221,7 @@ jobs:
         with:
           gradle-version: wrapper
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: gradle-cache
         with:
           path: |
@@ -232,14 +232,14 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Download Docker binaries
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v7.0.0
         with:
           pattern: docker-built-shared-objects-*
           merge-multiple: true
           path: src/main/resources/
 
       - name: Download Mac binaries
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v7.0.0
         with:
           name: macos-built-shared-objects
           path: src/main/resources/
@@ -264,11 +264,11 @@ jobs:
         java-version: [ 21 ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: "${{ matrix.java-distribution }}"
           java-version: "${{ matrix.java-version }}"
@@ -277,7 +277,7 @@ jobs:
         with:
           gradle-version: wrapper
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: gradle-cache
         with:
           path: |
@@ -288,14 +288,14 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Download Docker binaries
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v7.0.0
         with:
           pattern: docker-built-shared-objects-*
           merge-multiple: true
           path: src/main/resources/
 
       - name: Download Mac binaries
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v7.0.0
         with:
           name: macos-built-shared-objects
           path: src/main/resources/

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: "adopt"
           java-version: "15"
@@ -27,7 +27,7 @@ jobs:
           gradle-version: wrapper
 
       - name: Setup Gradle Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/cache` | [`v4`](https://github.com/actions/cache/releases/tag/v4) | [`v5`](https://github.com/actions/cache/releases/tag/v5) | [Release](https://github.com/actions/cache/releases/tag/v5) | release.yml, tests.yml, website.yml |
| `actions/checkout` | [`v3`](https://github.com/actions/checkout/releases/tag/v3), [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | release.yml, tests.yml, website.yml |
| `actions/download-artifact` | [`v4.1.7`](https://github.com/actions/download-artifact/releases/tag/v4.1.7) | [`v7.0.0`](https://github.com/actions/download-artifact/releases/tag/v7.0.0) | [Release](https://github.com/actions/download-artifact/releases/tag/v7) | release.yml, tests.yml |
| `actions/setup-java` | [`v2`](https://github.com/actions/setup-java/releases/tag/v2), [`v3`](https://github.com/actions/setup-java/releases/tag/v3), [`v4`](https://github.com/actions/setup-java/releases/tag/v4) | [`v5`](https://github.com/actions/setup-java/releases/tag/v5) | [Release](https://github.com/actions/setup-java/releases/tag/v5) | release.yml, tests.yml, website.yml |
| `actions/upload-artifact` | [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) | release.yml, tests.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
