### PR TITLE
ci: declare contents:read on slack-alert workflow

### DIFF
--- a/.github/workflows/slack-alert.yml
+++ b/.github/workflows/slack-alert.yml
@@ -5,6 +5,9 @@ on:
     workflows: [tests]
     types: [completed]
 
+permissions:
+  contents: read
+
 jobs:
   on-failure:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `slack-alert` workflow triggers on `workflow_run`, which runs with the same default-branch context that `push` events use, not the read-only context used for `pull_request` from forks. Right now there's no explicit `permissions:` block on this workflow, so the token receives whatever the repo default grants.

The job itself only calls `slackapi/slack-github-action@v2.1.1` with `SLACK_WEBHOOK_URL`. It never invokes the GitHub API or touches the repo, so pinning the workflow to `contents: read` makes the minimum-scope intent explicit. This narrows the blast radius if the third-party Slack action is ever compromised (cf. tj-actions/changed-files CVE-2025-30066).

Style matches release.yml and website.yml, which already carry explicit `permissions:` blocks.

I deliberately left tests.yml out of this patch: it uses `actions/cache`, and that interacts with the explicit-permissions story in a way I'd rather handle separately if you want it tightened up too. Happy to follow up.