### PR TITLE
Fix #158: Enforce unique inputs in cellsToMultiPolygon by requiring Set

### DIFF
--- a/src/main/java/com/uber/h3core/H3Core.java
+++ b/src/main/java/com/uber/h3core/H3Core.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -724,17 +725,17 @@ public class H3Core {
 
   /** Create polygons from a set of contiguous indexes */
   public List<List<List<LatLng>>> cellAddressesToMultiPolygon(
-      Collection<String> h3Addresses, boolean geoJson) {
-    List<Long> indices = stringToH3List(h3Addresses);
+      Set<String> h3Addresses, boolean geoJson) {
+    Set<Long> indices = h3Addresses.stream().map(this::stringToH3).collect(Collectors.toSet());
 
     return cellsToMultiPolygon(indices, geoJson);
   }
 
   /** Create polygons from a set of contiguous indexes */
-  public List<List<List<LatLng>>> cellsToMultiPolygon(Collection<Long> h3, boolean geoJson) {
-    long[] h3AsArray = collectionToLongArray(h3);
-
-    ArrayList<List<List<LatLng>>> result = new ArrayList<>();
+  public List<List<List<LatLng>>> cellsToMultiPolygon(Set<Long> h3, boolean geoJson) {
+  long[] h3AsArray = collectionToLongArray(h3);
+  
+  ArrayList<List<List<LatLng>>> result = new ArrayList<>();
 
     h3Api.cellsToLinkedMultiPolygon(h3AsArray, result);
 

--- a/src/main/java/com/uber/h3core/H3CoreV3.java
+++ b/src/main/java/com/uber/h3core/H3CoreV3.java
@@ -446,12 +446,12 @@ public class H3CoreV3 {
   /** Create polygons from a set of contiguous indexes */
   public List<List<List<LatLng>>> h3AddressSetToMultiPolygon(
       Collection<String> h3Addresses, boolean geoJson) {
-    return h3Api.cellAddressesToMultiPolygon(h3Addresses, geoJson);
+    return h3Api.cellAddressesToMultiPolygon(new java.util.HashSet<>(h3Addresses), geoJson);
   }
 
   /** Create polygons from a set of contiguous indexes */
   public List<List<List<LatLng>>> h3SetToMultiPolygon(Collection<Long> h3, boolean geoJson) {
-    return h3Api.cellsToMultiPolygon(h3, geoJson);
+    return h3Api.cellsToMultiPolygon(new java.util.HashSet<>(h3), geoJson);
   }
 
   /** Returns the resolution of the provided index */

--- a/src/test/java/com/uber/h3core/TestRegion.java
+++ b/src/test/java/com/uber/h3core/TestRegion.java
@@ -340,7 +340,7 @@ class TestRegion extends BaseTestH3Core {
     inputHexagons.remove(0x85283097fffffffL);
     inputHexagons.remove(0x8528309bfffffffL);
 
-    List<List<LatLng>> geo = h3.cellsToMultiPolygon(inputHexagons, true).get(0);
+    List<List<LatLng>> geo = h3.cellsToMultiPolygon(new java.util.HashSet<>(inputHexagons), true).get(0);
 
     List<LatLng> outline = geo.remove(0); // geo is now holes
 
@@ -351,7 +351,7 @@ class TestRegion extends BaseTestH3Core {
 
   @Test
   void h3SetToMultiPolygonEmpty() {
-    assertEquals(0, h3.cellsToMultiPolygon(new ArrayList<Long>(), false).size());
+    assertEquals(0, h3.cellsToMultiPolygon(new java.util.HashSet<Long>(), false).size());
   }
 
   @Test
@@ -360,7 +360,7 @@ class TestRegion extends BaseTestH3Core {
 
     List<LatLng> actualBounds = h3.cellToBoundary(testIndex);
     List<List<List<LatLng>>> multiBounds =
-        h3.cellsToMultiPolygon(ImmutableList.of(testIndex), true);
+        h3.cellsToMultiPolygon(ImmutableSet.of(testIndex), true);
 
     // This is tricky, because output in an order starting from any vertex
     // would also be correct, but that's difficult to assert and there's
@@ -386,7 +386,7 @@ class TestRegion extends BaseTestH3Core {
 
     List<LatLng> actualBounds = h3.cellToBoundary(testIndex);
     List<List<List<LatLng>>> multiBounds =
-        h3.cellsToMultiPolygon(ImmutableList.of(testIndex), false);
+        h3.cellsToMultiPolygon(ImmutableSet.of(testIndex), false);
 
     // This is tricky, because output in an order starting from any vertex
     // would also be correct, but that's difficult to assert and there's
@@ -416,7 +416,7 @@ class TestRegion extends BaseTestH3Core {
 
     // Note this is different than the h3core-js bindings, in that it uses GeoJSON (possible bug)
     List<List<List<LatLng>>> multiBounds =
-        h3.cellsToMultiPolygon(ImmutableList.of(testIndex, testIndex2), false);
+        h3.cellsToMultiPolygon(ImmutableSet.of(testIndex, testIndex2), false);
 
     assertEquals(1, multiBounds.size());
     assertEquals(1, multiBounds.get(0).size());
@@ -450,7 +450,7 @@ class TestRegion extends BaseTestH3Core {
     long testIndex2 = 0x8928308280fffffL;
 
     List<List<List<LatLng>>> multiBounds =
-        h3.cellsToMultiPolygon(ImmutableList.of(testIndex, testIndex2), false);
+        h3.cellsToMultiPolygon(ImmutableSet.of(testIndex, testIndex2), false);
 
     assertEquals(2, multiBounds.size());
     assertEquals(1, multiBounds.get(0).size());
@@ -464,7 +464,7 @@ class TestRegion extends BaseTestH3Core {
     // Six hexagons in a ring around a hole
     List<List<List<LatLng>>> multiBounds =
         h3.cellAddressesToMultiPolygon(
-            ImmutableList.of(
+            ImmutableSet.of(
                 "892830828c7ffff",
                 "892830828d7ffff",
                 "8928308289bffff",
@@ -488,7 +488,7 @@ class TestRegion extends BaseTestH3Core {
       addresses.add(h3.latLngToCellAddress(0, i * 0.01, 15));
     }
 
-    List<List<List<LatLng>>> multiBounds = h3.cellAddressesToMultiPolygon(addresses, false);
+    List<List<List<LatLng>>> multiBounds = h3.cellAddressesToMultiPolygon(new java.util.HashSet<>(addresses), false);
 
     assertEquals(numHexes, multiBounds.size());
     for (int i = 0; i < multiBounds.size(); i++) {
@@ -605,6 +605,6 @@ class TestRegion extends BaseTestH3Core {
             617683648067665919L,
             617683648068976639L,
             617683648028606463L);
-    assertThrows(H3Exception.class, () -> h3.cellsToMultiPolygon(cells, true));
+    assertThrows(H3Exception.class, () -> h3.cellsToMultiPolygon(new java.util.HashSet<>(cells), true));
   }
 }

--- a/src/test/java/com/uber/h3core/benchmarking/CellsToMultiPolygonBenchmark.java
+++ b/src/test/java/com/uber/h3core/benchmarking/CellsToMultiPolygonBenchmark.java
@@ -36,13 +36,13 @@ public class CellsToMultiPolygonBenchmark {
   @Benchmark
   @BenchmarkMode(Mode.Throughput)
   public List<List<List<LatLng>>> benchmarkH3SetToMultiPolygon2() {
-    return BenchmarkState.h3Core.cellsToMultiPolygon(BenchmarkState.list2, false);
+    return BenchmarkState.h3Core.cellsToMultiPolygon(new java.util.HashSet<>(BenchmarkState.list2), false);
   }
 
   @Benchmark
   @BenchmarkMode(Mode.Throughput)
   public List<List<List<LatLng>>> benchmarkH3SetToMultiPolygon20() {
-    return BenchmarkState.h3Core.cellsToMultiPolygon(BenchmarkState.list20, true);
+    return BenchmarkState.h3Core.cellsToMultiPolygon(new java.util.HashSet<>(BenchmarkState.list20), true);
   }
 
   @State(Scope.Benchmark)


### PR DESCRIPTION
### Description
Fixes #158. 

As discussed in the issue, passing duplicate hexagon indices into `cellsToMultiPolygon` can cause a `SIGSEGV` crash in the underlying C library. 

This PR enforces uniqueness at the API level by updating the method signatures in `H3Core` to require a `Set` instead of a `Collection`. 

**Changes included:**
* Updated `cellsToMultiPolygon` and `cellAddressesToMultiPolygon` in `H3Core.java` to require `Set`.
* Updated the `H3CoreV3` backward-compatibility layer to wrap incoming Collections in a `HashSet` before delegating to the core API, ensuring legacy users don't experience breaking API changes.
* Updated the test suite (swapped `ImmutableList` for `ImmutableSet` and wrapped legacy list variables) to compile against the new stricter API.

### Testing
Local Java compilation succeeds. Relying on CI to execute the test suite against the compiled native binaries.