### PR TITLE
Fix #97: Allow custom native library directory via h3.native.dir

### DIFF
--- a/src/main/java/com/uber/h3core/H3CoreLoader.java
+++ b/src/main/java/com/uber/h3core/H3CoreLoader.java
@@ -97,7 +97,7 @@ public final class H3CoreLoader {
     // Check if the user specified a custom directory for native libraries
     String customDir = System.getProperty("h3.native.dir");
     File dir = customDir != null ? new File(customDir) : null;
-    
+
     // Ensure the custom directory exists
     if (dir != null && !dir.exists()) {
       dir.mkdirs();
@@ -109,7 +109,7 @@ public final class H3CoreLoader {
       // write.
       final FileAttribute<Set<PosixFilePermission>> attr =
           PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------"));
-      
+
       if (dir != null) {
         return Files.createTempFile(dir.toPath(), "libh3-java", os.getSuffix(), attr).toFile();
       } else {

--- a/src/main/java/com/uber/h3core/H3CoreLoader.java
+++ b/src/main/java/com/uber/h3core/H3CoreLoader.java
@@ -94,16 +94,35 @@ public final class H3CoreLoader {
   }
 
   private static File createTempLibraryFile(OperatingSystem os) throws IOException {
+    // Check if the user specified a custom directory for native libraries
+    String customDir = System.getProperty("h3.native.dir");
+    File dir = customDir != null ? new File(customDir) : null;
+    
+    // Ensure the custom directory exists
+    if (dir != null && !dir.exists()) {
+      dir.mkdirs();
+    }
+
     if (os.isPosix()) {
       // Note this is already done by the implementation of Files.createTempFile that I looked at,
       // but the javadoc does not seem to gaurantee the permissions will be restricted to owner
       // write.
       final FileAttribute<Set<PosixFilePermission>> attr =
           PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------"));
-      return Files.createTempFile("libh3-java", os.getSuffix(), attr).toFile();
+      
+      if (dir != null) {
+        return Files.createTempFile(dir.toPath(), "libh3-java", os.getSuffix(), attr).toFile();
+      } else {
+        return Files.createTempFile("libh3-java", os.getSuffix(), attr).toFile();
+      }
     } else {
       // When not a POSIX OS, try to ensure the permissions are secure
-      final File f = Files.createTempFile("libh3-java", os.getSuffix()).toFile();
+      final File f;
+      if (dir != null) {
+        f = Files.createTempFile(dir.toPath(), "libh3-java", os.getSuffix()).toFile();
+      } else {
+        f = Files.createTempFile("libh3-java", os.getSuffix()).toFile();
+      }
       f.setReadable(true, true);
       f.setWritable(true, true);
       f.setExecutable(true, true);


### PR DESCRIPTION
### Description
Fixes #97.

Currently, `H3CoreLoader` always extracts the native library (`.so` / `.dll` / `.dylib`) to the operating system's default temporary directory (e.g., `/tmp/`). As reported in #97, this causes `UnsatisfiedLinkError`s in distributed environments like Apache Flink or Spark, where worker nodes frequently clean up or isolate the `/tmp` directory between task restorations.

This PR introduces a safe escape hatch for these environments. It updates `createTempLibraryFile` to check for a Java system property named `h3.native.dir`. 
* If provided, the library is extracted to that stable, user-defined directory.
* If not provided, it falls back to the existing `java.io.tmpdir` behavior.

### Testing
Local Java compilation succeeds. Relying on the CI pipeline to compile the native binaries and execute the test suite to ensure the extraction logic functions correctly across OS platforms.