### PR TITLE
Test against the upstream inputfiles

### DIFF
--- a/src/test/java/com/uber/h3core/BaseTestH3Core.java
+++ b/src/test/java/com/uber/h3core/BaseTestH3Core.java
@@ -15,6 +15,7 @@
  */
 package com.uber.h3core;
 
+import com.uber.h3core.util.LatLng;
 import java.io.IOException;
 import org.junit.jupiter.api.BeforeAll;
 
@@ -27,5 +28,21 @@ public abstract class BaseTestH3Core {
   @BeforeAll
   public static void setup() throws IOException {
     h3 = H3Core.newInstance();
+  }
+
+  public static boolean floatEquals(double f1, double f2) {
+    return floatEquals(f1, f2, EPSILON);
+  }
+
+  public static boolean floatEquals(double f1, double f2, double epsilon) {
+    return (Math.abs(f1 - f2) < epsilon);
+  }
+
+  public static boolean latLngEquals(LatLng l1, LatLng l2) {
+    return latLngEquals(l1, l2, EPSILON);
+  }
+
+  public static boolean latLngEquals(LatLng l1, LatLng l2, double epsilon) {
+    return floatEquals(l1.lat, l2.lat, epsilon) && floatEquals(l1.lng, l2.lng, epsilon);
   }
 }

--- a/src/test/java/com/uber/h3core/inputfiles/TestCellToBoundary.java
+++ b/src/test/java/com/uber/h3core/inputfiles/TestCellToBoundary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 Uber Technologies, Inc.
+ * Copyright 2026 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/uber/h3core/inputfiles/TestCellToBoundary.java
+++ b/src/test/java/com/uber/h3core/inputfiles/TestCellToBoundary.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017-2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.h3core.inputfiles;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.uber.h3core.BaseTestH3Core;
+import com.uber.h3core.util.LatLng;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+import org.junit.jupiter.api.Test;
+
+/** Test input files from core library. */
+class TestCellToBoundary extends BaseTestH3Core {
+  private static void testFile(Path path) {
+    try {
+      try (Scanner in = new Scanner(path, "UTF-8")) {
+        while (in.hasNext()) {
+          String cell = in.next();
+
+          String start = in.next();
+          assertEquals("{", start);
+
+          List<LatLng> verts = new ArrayList<>();
+          while (in.hasNextDouble()) {
+            double lat = in.nextDouble();
+            double lng = in.nextDouble();
+
+            verts.add(new LatLng(lat, lng));
+          }
+
+          String end = in.next();
+          assertEquals("}", end);
+          assertTrue(verts.size() > 0);
+          assertTrue(verts.size() <= 10);
+
+          List<LatLng> actual = h3.cellToBoundary(cell);
+          assertEquals(verts.size(), actual.size());
+          for (int i = 0; i < verts.size(); i++) {
+            assertTrue(latLngEquals(verts.get(i), actual.get(i)));
+          }
+        }
+      }
+    } catch (IOException ioe) {
+      throw new RuntimeException(ioe);
+    }
+  }
+
+  @Test
+  void test() throws IOException {
+    PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:**/*cells.txt");
+    assertEquals(
+        39,
+        Files.walk(Path.of("target/h3/tests/inputfiles"), 1)
+            .filter(
+                (path) -> {
+                  if (matcher.matches(path)) {
+                    testFile(path);
+
+                    return true;
+                  } else {
+                    return false;
+                  }
+                })
+            .count());
+  }
+}

--- a/src/test/java/com/uber/h3core/inputfiles/TestCellToLatLng.java
+++ b/src/test/java/com/uber/h3core/inputfiles/TestCellToLatLng.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.h3core.inputfiles;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.uber.h3core.BaseTestH3Core;
+import com.uber.h3core.util.LatLng;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.Scanner;
+import org.junit.jupiter.api.Test;
+
+/** Test input files from core library. */
+class TestCellToLatLng extends BaseTestH3Core {
+  private static void testFile(Path path) {
+    try {
+      try (Scanner in = new Scanner(path, "UTF-8")) {
+        while (in.hasNext()) {
+          String cell = in.next();
+          double lat = in.nextDouble();
+          double lng = in.nextDouble();
+
+          LatLng actual = h3.cellToLatLng(cell);
+
+          double epsilon = 0.000001 * Math.PI / 180.0;
+
+          assertTrue(latLngEquals(actual, new LatLng(lat, lng), epsilon));
+
+          int res = h3.getResolution(cell);
+          String cell2 = h3.latLngToCellAddress(actual.lat, actual.lng, res);
+          assertEquals(cell, cell2);
+        }
+      }
+    } catch (IOException ioe) {
+      throw new RuntimeException(ioe);
+    }
+  }
+
+  @Test
+  void test() throws IOException {
+    PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:**/res*ic.txt");
+    assertEquals(
+        5,
+        Files.walk(Path.of("target/h3/tests/inputfiles"), 1)
+            .filter(
+                (path) -> {
+                  if (matcher.matches(path)) {
+                    testFile(path);
+
+                    return true;
+                  } else {
+                    return false;
+                  }
+                })
+            .count());
+  }
+}

--- a/src/test/java/com/uber/h3core/inputfiles/TestLatLngToCell.java
+++ b/src/test/java/com/uber/h3core/inputfiles/TestLatLngToCell.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 Uber Technologies, Inc.
+ * Copyright 2026 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/uber/h3core/inputfiles/TestLatLngToCell.java
+++ b/src/test/java/com/uber/h3core/inputfiles/TestLatLngToCell.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017-2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.h3core.inputfiles;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.uber.h3core.BaseTestH3Core;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.Scanner;
+import org.junit.jupiter.api.Test;
+
+/** Test input files from core library. */
+class TestLatLngToCell extends BaseTestH3Core {
+  private static void testFile(Path path) {
+    try {
+      try (Scanner in = new Scanner(path, "UTF-8")) {
+        while (in.hasNext()) {
+          String cell = in.next();
+          double lat = in.nextDouble();
+          double lng = in.nextDouble();
+
+          int res = h3.getResolution(cell);
+
+          String cell2 = h3.latLngToCellAddress(lat, lng, res);
+
+          assertEquals(cell, cell2);
+        }
+      }
+    } catch (IOException ioe) {
+      throw new RuntimeException(ioe);
+    }
+  }
+
+  @Test
+  void test() throws IOException {
+    PathMatcher matcher =
+        FileSystems.getDefault().getPathMatcher("glob:**/{bc*centers,rand*centers}.txt");
+    assertEquals(
+        35,
+        Files.walk(Path.of("target/h3/tests/inputfiles"), 1)
+            .filter(
+                (path) -> {
+                  if (matcher.matches(path)) {
+                    testFile(path);
+
+                    return true;
+                  } else {
+                    return false;
+                  }
+                })
+            .count());
+  }
+}


### PR DESCRIPTION
The purpose of this test is to use the `inputfiles` from uber/h3 as the actual, portable test suite. Then, by building up a set of test files in uber/h3, they can be reused across different bindings or H3 implementations.

cc @dmitryzv @nrabinowitz 