### PR TITLE
Fix Android native math library linkage

### DIFF
--- a/src/main/c/h3-java/CMakeLists.txt
+++ b/src/main/c/h3-java/CMakeLists.txt
@@ -70,11 +70,12 @@ target_link_libraries(h3-java "${H3_BUILD_ROOT}/${H3_CORE_LIBRARY_PATH}${CMAKE_S
 option(H3_JAVA_ANDROID "Whether to enable Android specific build flags")
 if(H3_JAVA_ANDROID)
     target_link_options(h3-java PRIVATE "-Wl,-z,max-page-size=16384")
-endif()
-
-find_library(M_LIB m)
-if(M_LIB)
-    target_link_libraries(h3-java ${M_LIB})
+    target_link_libraries(h3-java m)
+else()
+    find_library(M_LIB m)
+    if(M_LIB)
+        target_link_libraries(h3-java ${M_LIB})
+    endif()
 endif()
 
 find_program(CLANG_FORMAT_PATH clang-format)

--- a/src/main/c/h3-java/build-h3.sh
+++ b/src/main/c/h3-java/build-h3.sh
@@ -211,6 +211,11 @@ for image in $DOCKCROSS_IMAGES; do
     # Perform the actual build inside Docker
     $BUILD_ROOT/dockcross --args "-v $JAVA_HOME:/java" src/main/c/h3-java/build-h3-docker.sh "$BUILD_ROOT" "$UPGRADE_CMAKE" "$CMAKE_ROOT" "$SPECIAL_ANDROID_FLAGS"
 
+    if [[ "$image" == android-* ]]; then
+        $BUILD_ROOT/dockcross readelf -d "$BUILD_ROOT/lib/libh3-java.so" |
+            grep -q 'Shared library: \[libm.so\]'
+    fi
+
     # Copy the built artifact into the source tree so it can be included in the
     # built JAR.
     OUTPUT_ROOT=src/main/resources/$image


### PR DESCRIPTION
## Summary

- link `libm` explicitly when building `libh3-java.so` for Android
- retain the existing `find_library` behavior on other platforms
- fail Android cross-builds when the generated ELF does not declare `libm.so`

Fixes #206.

## Reproduction

Using `com.uber:h3-android:4.4.0` on an Android 16 ARM64 emulator, `H3Core.newSystemInstance()` failed with:

```
java.lang.UnsatisfiedLinkError: dlopen failed: cannot locate symbol "cos" referenced by "libh3-java.so"
```

The published library's dynamic section declared `liblog.so`, `libdl.so`, and `libc.so`, but not `libm.so`.

## Verification

- reproduced the failure with an Android instrumentation test on an Android 16 ARM64 emulator
- rebuilt the Android ARM64 native library with this change
- verified `readelf -d` includes `NEEDED Shared library: [libm.so]`
- repackaged the AAR and reran the same instrumentation test successfully
- ran `./gradlew spotlessCheck compileJava`

> This pull request was created using Codex with GPT-5.6 Sol (Medium reasoning).